### PR TITLE
feat: What's New notification + changelog + connection sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to Viewstor are documented here. Format based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [0.2.1] — 2026-03-30
+
+### Added
+- "What's New" notification after extension update with link to changelog
+
+## [0.2.0] — 2026-03-29
+
+### Added
+- Standalone MCP server for CLI agents (Claude Code, Cline, etc.)
+- 6 MCP tools: `list_connections`, `get_schema`, `execute_query`, `get_table_data`, `get_table_info`, `add_connection`
+- Connection store reads from `~/.viewstor/connections.json` and `.vscode/viewstor.json`
+
+## [0.1.2] — 2026-03-29
+
+### Added
+- Copilot Chat participant (`@viewstor`) with `/schema`, `/describe`, `/query` commands
+- Wiki with migration guides for DBeaver, DataGrip, pgAdmin
+
+### Fixed
+- Release workflow permissions for GitHub Releases
+
+## [0.1.1] — 2026-03-29
+
+### Added
+- Internationalization (i18n) — 12 languages: Chinese, Japanese, Korean, German, French, Spanish, Portuguese, Russian, Arabic, Hindi, Bengali, English
+- `.vscodeignore` to reduce package size
+
+### Fixed
+- Redis `disconnect()` now properly awaits `quit()`
+- ClickHouse SQL injection in `getEstimatedRowCount` — uses parameterized queries
+- ClickHouse `AbortController` race condition — local variable per query
+- PostgreSQL tunnel leak on connect failure — try-catch with cleanup
+- `IndexHintProvider` clears `debounceTimer` in `dispose()`
+- `CompletionProvider` tracks and clears cache timeout IDs
+- `FolderForm` persists scope on folder creation
+
+### Changed
+- ClickHouse `getSchema` uses batch `system.tables` + `system.columns` instead of N+1 DESCRIBE
+- ClickHouse `execute` uses `JSON` format for column type metadata
+- ExportService precompiles RegExp in `escapeField`
+- README rewritten: motivation-first structure with competitor comparison
+
+## [0.1.0] — 2026-03-29
+
+### Added
+- Initial release
+- PostgreSQL, Redis, ClickHouse drivers
+- Schema browser with tree view
+- Query editor with SQL autocomplete and index hints
+- Result grid with server-side pagination, inline editing, export
+- Safe mode (block/warn/off) with EXPLAIN-based Seq Scan detection
+- Read-only mode per connection and folder (inherited)
+- Connection import from DBeaver, DataGrip, pgAdmin
+- Color-coded nested folders with drag-and-drop
+- MCP commands for VS Code AI agents
+- Query history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Viewstor are documented here. Format based on [Keep a Cha
 
 ### Added
 - "What's New" notification after extension update with link to changelog
+- `reload_connections` MCP tool for CLI agents to re-read config files
+- Bidirectional connection sync between VS Code extension and standalone MCP server via `~/.viewstor/connections.json`
+
+### Fixed
+- VS Code extension now reads connections from `~/.viewstor/connections.json` on startup
+- VS Code extension now writes user connections to `~/.viewstor/connections.json` on save
 
 ## [0.2.0] — 2026-03-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ All auto-connect. Returns structured JSON or `{ error }`.
 
 `src/mcp-server/connectionStore.ts` — reads connections from `~/.viewstor/connections.json` (user) and `.vscode/viewstor.json` (project). Manages driver lifecycle.
 
-6 tools: `list_connections`, `get_schema`, `execute_query`, `get_table_data`, `get_table_info`, `add_connection`.
+7 tools: `list_connections`, `get_schema`, `execute_query`, `get_table_data`, `get_table_info`, `add_connection`, `reload_connections`.
 
 Usage in Claude Code config:
 ```json
@@ -139,3 +139,12 @@ Usage in Claude Code config:
 - PG arrays: `pgArrayToString()` renders `{curly braces}` instead of JSON `[brackets]`
 - ClickHouse getSchema uses batch queries to `system.tables` and `system.columns` (not per-table DESCRIBE)
 - ClickHouse execute uses `JSON` format (not `JSONEachRow`) to get column types from response metadata
+
+## Process
+
+When implementing a new feature, ALWAYS update in the same PR:
+1. **README.md** — add/update the feature in the appropriate section
+2. **CHANGELOG.md** — add entry under `[Unreleased]` or the current version
+3. **CLAUDE.md** — update architecture docs if new files/modules are added
+4. **Wiki** — update relevant pages (push to `git@github.com:Siyet/viewstor.wiki.git` in `/tmp/viewstor-wiki/`)
+5. **l10n translations** — if new user-facing strings are added

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Two MCP interfaces — pick the one that fits your workflow:
 }
 ```
 
-6 tools: `list_connections`, `get_schema`, `execute_query`, `get_table_data`, `get_table_info`, `add_connection`. Reads connections from `~/.viewstor/connections.json` and `.vscode/viewstor.json`.
+7 tools: `list_connections`, `get_schema`, `execute_query`, `get_table_data`, `get_table_info`, `add_connection`, `reload_connections`. Reads connections from `~/.viewstor/connections.json` and `.vscode/viewstor.json`. Connections sync bidirectionally with the VS Code extension. See the [MCP Server wiki page](https://github.com/Siyet/viewstor/wiki/MCP-Server) for setup instructions.
 
 All MCP interfaces auto-connect and respect read-only mode.
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ Schema context is injected automatically from the active connection. Slash comma
 
 ### AI Agent Integration (MCP)
 
-Five commands for Claude Code, Cursor, Copilot, and other MCP-capable tools:
+Two MCP interfaces — pick the one that fits your workflow:
+
+**VS Code MCP commands** (for Copilot, Cursor — agents running inside VS Code):
 
 | Command | What it does |
 |---|---|
@@ -135,7 +137,22 @@ Five commands for Claude Code, Cursor, Copilot, and other MCP-capable tools:
 | `viewstor.mcp.getTableData` | Fetch rows with limit |
 | `viewstor.mcp.getTableInfo` | Column metadata, PKs, nullability |
 
-All commands auto-connect and respect read-only mode.
+**Standalone MCP server** (for Claude Code, Cline — CLI agents running outside VS Code):
+
+```json
+{
+  "mcpServers": {
+    "viewstor": {
+      "command": "node",
+      "args": ["/path/to/viewstor/dist/mcp-server.js"]
+    }
+  }
+}
+```
+
+6 tools: `list_connections`, `get_schema`, `execute_query`, `get_table_data`, `get_table_info`, `add_connection`. Reads connections from `~/.viewstor/connections.json` and `.vscode/viewstor.json`.
+
+All MCP interfaces auto-connect and respect read-only mode.
 
 ### Other
 
@@ -170,7 +187,7 @@ All shortcuts use physical key codes — work on any keyboard layout.
 ### Prerequisites
 
 - Node.js 18+
-- VS Code 1.85+
+- VS Code 1.93+
 - Docker (for e2e tests)
 
 ### Commands
@@ -198,6 +215,10 @@ Unit tests use [vitest](https://vitest.dev/). E2E tests use [testcontainers](htt
 ## Contributing
 
 See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a full list of changes per version.
 
 ## License
 

--- a/l10n/bundle.l10n.ar.json
+++ b/l10n/bundle.l10n.ar.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "حدد اسم الجدول. مثال: `@viewstor /describe users`",
   "Failed to describe table: {0}": "فشل وصف الجدول: {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "لا يتوفر نموذج لغوي. تأكد من تثبيت GitHub Copilot وتسجيل الدخول.",
-  "Language model error: {0}": "خطأ في النموذج اللغوي: {0}"
+  "Language model error: {0}": "خطأ في النموذج اللغوي: {0}",
+  "Viewstor updated to v{0}": "تم تحديث Viewstor إلى الإصدار v{0}",
+  "See Changes": "عرض التغييرات",
+  "Don't show again": "عدم الإظهار مجددًا"
 }

--- a/l10n/bundle.l10n.bn.json
+++ b/l10n/bundle.l10n.bn.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "একটি টেবিলের নাম উল্লেখ করুন। উদাহরণ: `@viewstor /describe users`",
   "Failed to describe table: {0}": "টেবিল বর্ণনা করতে ব্যর্থ: {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "কোনো ভাষা মডেল উপলব্ধ নেই। নিশ্চিত করুন যে GitHub Copilot ইনস্টল এবং সাইন ইন করা আছে।",
-  "Language model error: {0}": "ভাষা মডেল ত্রুটি: {0}"
+  "Language model error: {0}": "ভাষা মডেল ত্রুটি: {0}",
+  "Viewstor updated to v{0}": "Viewstor v{0}-এ আপডেট হয়েছে",
+  "See Changes": "পরিবর্তনগুলি দেখুন",
+  "Don't show again": "আর দেখাবেন না"
 }

--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "Geben Sie einen Tabellennamen an. Beispiel: `@viewstor /describe users`",
   "Failed to describe table: {0}": "Tabelle konnte nicht beschrieben werden: {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "Kein Sprachmodell verfügbar. Stellen Sie sicher, dass GitHub Copilot installiert und angemeldet ist.",
-  "Language model error: {0}": "Sprachmodellfehler: {0}"
+  "Language model error: {0}": "Sprachmodellfehler: {0}",
+  "Viewstor updated to v{0}": "Viewstor wurde auf v{0} aktualisiert",
+  "See Changes": "Änderungen anzeigen",
+  "Don't show again": "Nicht mehr anzeigen"
 }

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "Especifique un nombre de tabla. Ejemplo: `@viewstor /describe users`",
   "Failed to describe table: {0}": "Error al describir la tabla: {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "No hay modelo de lenguaje disponible. Asegúrese de que GitHub Copilot esté instalado e iniciada la sesión.",
-  "Language model error: {0}": "Error del modelo de lenguaje: {0}"
+  "Language model error: {0}": "Error del modelo de lenguaje: {0}",
+  "Viewstor updated to v{0}": "Viewstor se actualizó a v{0}",
+  "See Changes": "Ver cambios",
+  "Don't show again": "No volver a mostrar"
 }

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "Spécifiez un nom de table. Exemple : `@viewstor /describe users`",
   "Failed to describe table: {0}": "Impossible de décrire la table : {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "Aucun modèle de langage disponible. Assurez-vous que GitHub Copilot est installé et connecté.",
-  "Language model error: {0}": "Erreur du modèle de langage : {0}"
+  "Language model error: {0}": "Erreur du modèle de langage : {0}",
+  "Viewstor updated to v{0}": "Viewstor a été mis à jour en v{0}",
+  "See Changes": "Voir les nouveautés",
+  "Don't show again": "Ne plus afficher"
 }

--- a/l10n/bundle.l10n.hi.json
+++ b/l10n/bundle.l10n.hi.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "टेबल का नाम निर्दिष्ट करें। उदाहरण: `@viewstor /describe users`",
   "Failed to describe table: {0}": "टेबल का वर्णन करने में विफल: {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "कोई भाषा मॉडल उपलब्ध नहीं है। सुनिश्चित करें कि GitHub Copilot इंस्टॉल और साइन इन है।",
-  "Language model error: {0}": "भाषा मॉडल त्रुटि: {0}"
+  "Language model error: {0}": "भाषा मॉडल त्रुटि: {0}",
+  "Viewstor updated to v{0}": "Viewstor v{0} में अपडेट हो गया",
+  "See Changes": "बदलाव देखें",
+  "Don't show again": "दोबारा न दिखाएँ"
 }

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "テーブル名を指定してください。例: `@viewstor /describe users`",
   "Failed to describe table: {0}": "テーブルの説明に失敗しました: {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "利用可能な言語モデルがありません。GitHub Copilot がインストールされ、サインインしていることを確認してください。",
-  "Language model error: {0}": "言語モデルエラー: {0}"
+  "Language model error: {0}": "言語モデルエラー: {0}",
+  "Viewstor updated to v{0}": "Viewstor が v{0} に更新されました",
+  "See Changes": "変更内容を確認",
+  "Don't show again": "今後表示しない"
 }

--- a/l10n/bundle.l10n.ko.json
+++ b/l10n/bundle.l10n.ko.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "테이블 이름을 지정하세요. 예: `@viewstor /describe users`",
   "Failed to describe table: {0}": "테이블 설명 실패: {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "사용 가능한 언어 모델이 없습니다. GitHub Copilot이 설치되어 있고 로그인되어 있는지 확인하세요.",
-  "Language model error: {0}": "언어 모델 오류: {0}"
+  "Language model error: {0}": "언어 모델 오류: {0}",
+  "Viewstor updated to v{0}": "Viewstor가 v{0}(으)로 업데이트되었습니다",
+  "See Changes": "변경 사항 보기",
+  "Don't show again": "다시 표시하지 않기"
 }

--- a/l10n/bundle.l10n.pt-br.json
+++ b/l10n/bundle.l10n.pt-br.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "Especifique um nome de tabela. Exemplo: `@viewstor /describe users`",
   "Failed to describe table: {0}": "Falha ao descrever a tabela: {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "Nenhum modelo de linguagem disponível. Verifique se o GitHub Copilot está instalado e conectado.",
-  "Language model error: {0}": "Erro do modelo de linguagem: {0}"
+  "Language model error: {0}": "Erro do modelo de linguagem: {0}",
+  "Viewstor updated to v{0}": "Viewstor atualizado para v{0}",
+  "See Changes": "Ver novidades",
+  "Don't show again": "Não mostrar novamente"
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "Укажите имя таблицы. Пример: `@viewstor /describe users`",
   "Failed to describe table: {0}": "Не удалось описать таблицу: {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "Языковая модель недоступна. Убедитесь, что GitHub Copilot установлен и выполнен вход.",
-  "Language model error: {0}": "Ошибка языковой модели: {0}"
+  "Language model error: {0}": "Ошибка языковой модели: {0}",
+  "Viewstor updated to v{0}": "Viewstor обновлён до v{0}",
+  "See Changes": "Что нового",
+  "Don't show again": "Больше не показывать"
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -56,5 +56,8 @@
   "Specify a table name. Example: `@viewstor /describe users`": "请指定表名。示例: `@viewstor /describe users`",
   "Failed to describe table: {0}": "描述表失败: {0}",
   "No language model available. Make sure GitHub Copilot is installed and signed in.": "没有可用的语言模型。请确保已安装 GitHub Copilot 并已登录。",
-  "Language model error: {0}": "语言模型错误: {0}"
+  "Language model error: {0}": "语言模型错误: {0}",
+  "Viewstor updated to v{0}": "Viewstor 已更新至 v{0}",
+  "See Changes": "查看更新内容",
+  "Don't show again": "不再显示"
 }

--- a/src/connections/connectionManager.ts
+++ b/src/connections/connectionManager.ts
@@ -1,4 +1,7 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import { ConnectionConfig, ConnectionState, ConnectionFolder } from '../types/connection';
 import { DatabaseDriver } from '../types/driver';
 import { SchemaObject } from '../types/schema';
@@ -7,6 +10,8 @@ import { createDriver } from '../drivers';
 const STORAGE_KEY = 'viewstor.connections';
 const FOLDERS_KEY = 'viewstor.connectionFolders';
 const PROJECT_FILE = '.vscode/viewstor.json';
+const USER_CONFIG_DIR = path.join(os.homedir(), '.viewstor');
+const USER_CONFIG_FILE = path.join(USER_CONFIG_DIR, 'connections.json');
 
 interface ProjectData {
   connections: ConnectionConfig[];
@@ -24,6 +29,7 @@ export class ConnectionManager {
   constructor(private readonly context: vscode.ExtensionContext) {
     this.loadConnections();
     this.loadFolders();
+    this.loadUserConfigFile();
     this.loadProjectData();
     this.watchProjectFile();
   }
@@ -42,6 +48,21 @@ export class ConnectionManager {
       folder.scope = folder.scope || 'user';
       this.folders.set(folder.id, folder);
     }
+  }
+
+  private loadUserConfigFile() {
+    try {
+      // fs imported at top level
+      if (!fs.existsSync(USER_CONFIG_FILE)) return;
+      const raw = fs.readFileSync(USER_CONFIG_FILE, 'utf8');
+      const data: ProjectData = JSON.parse(raw);
+      for (const config of data.connections || []) {
+        config.scope = config.scope || 'user';
+        if (!this.connections.has(config.id)) {
+          this.connections.set(config.id, { config, connected: false });
+        }
+      }
+    } catch { /* file doesn't exist or invalid — ok */ }
   }
 
   private loadProjectData() {
@@ -96,8 +117,21 @@ export class ConnectionManager {
       .filter(s => s.config.scope !== 'project')
       .map(s => s.config);
     await this.context.globalState.update(STORAGE_KEY, userConfigs);
+    // Sync user-scoped to ~/.viewstor/connections.json (for standalone MCP server)
+    this.saveUserConfigFile(userConfigs);
     // Save project-scoped to file
     await this.saveProjectData();
+  }
+
+  private saveUserConfigFile(configs: ConnectionConfig[]) {
+    try {
+      // fs imported at top level
+      if (!fs.existsSync(USER_CONFIG_DIR)) {
+        fs.mkdirSync(USER_CONFIG_DIR, { recursive: true });
+      }
+      const data: ProjectData = { connections: configs, folders: [] };
+      fs.writeFileSync(USER_CONFIG_FILE, JSON.stringify(data, null, 2), 'utf8');
+    } catch { /* ignore write errors */ }
   }
 
   private async saveFolders() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,6 +78,36 @@ export function activate(context: vscode.ExtensionContext) {
     connectionTreeView,
     reportBtn,
   );
+
+  // "What's New" notification after update
+  showWhatsNew(context);
+}
+
+function showWhatsNew(context: vscode.ExtensionContext) {
+  const ext = vscode.extensions.getExtension('Siyet.viewstor');
+  if (!ext) return;
+  const currentVersion: string = ext.packageJSON.version;
+  const lastVersion = context.globalState.get<string>('viewstor.lastVersion');
+  const suppressed = context.globalState.get<boolean>('viewstor.suppressWhatsNew', false);
+
+  context.globalState.update('viewstor.lastVersion', currentVersion);
+
+  if (!lastVersion || lastVersion === currentVersion || suppressed) return;
+
+  const seeChanges = vscode.l10n.t('See Changes');
+  const dontShow = vscode.l10n.t('Don\'t show again');
+  vscode.window.showInformationMessage(
+    vscode.l10n.t('Viewstor updated to v{0}', currentVersion),
+    seeChanges,
+    dontShow,
+  ).then(action => {
+    if (action === seeChanges) {
+      const changelogPath = vscode.Uri.joinPath(ext.extensionUri, 'CHANGELOG.md');
+      vscode.commands.executeCommand('markdown.showPreview', changelogPath);
+    } else if (action === dontShow) {
+      context.globalState.update('viewstor.suppressWhatsNew', true);
+    }
+  });
 }
 
 export function deactivate() {

--- a/src/mcp-server/connectionStore.ts
+++ b/src/mcp-server/connectionStore.ts
@@ -19,10 +19,11 @@ export class ConnectionStore {
   private drivers = new Map<string, DatabaseDriver>();
 
   constructor() {
-    this.load();
+    this.reload();
   }
 
-  private load() {
+  reload() {
+    this.connections.clear();
     // Load user-level config
     this.loadFile(USER_CONFIG_FILE, 'user');
 

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -94,6 +94,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['name', 'type', 'host', 'port'],
       },
     },
+    {
+      name: 'reload_connections',
+      description: 'Reload connections from config files (call after adding connections via VS Code or editing config files)',
+      inputSchema: { type: 'object' as const, properties: {} },
+    },
   ],
 }));
 
@@ -190,6 +195,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const config = { id, name: connName, type, host, port, username, password, database, ssl, readonly };
         await store.add(config);
         return jsonResponse({ id, name: connName, type, host, port, database, message: 'Connection added' });
+      }
+
+      case 'reload_connections': {
+        await store.disconnectAll();
+        store.reload();
+        const all = store.getAll();
+        return jsonResponse({ message: `Reloaded ${all.length} connection(s)`, connections: all.map(c => c.name) });
       }
 
       default:


### PR DESCRIPTION
## Summary

Closes #2

- "What's New" notification after extension update with See Changes / Don't show again
- CHANGELOG.md (Keep a Changelog format)
- Connection sync between VS Code extension and standalone MCP server (~/.viewstor/connections.json)
- Wiki updated with MCP Server page
- README updated with Changelog link and Wiki migration guide links
- l10n translations for 12 languages

## Test plan

- [ ] Update extension version → notification appears
- [ ] "See Changes" opens CHANGELOG.md preview
- [ ] "Don't show again" suppresses future notifications
- [ ] Add connection in VS Code → appears in ~/.viewstor/connections.json
- [ ] Add connection via MCP server → appears in VS Code after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)