### PR TITLE
release: v0.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,18 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run test:e2e
+
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,7 +3,6 @@
 .claude/**
 src/**
 l10n/nls/**
-node_modules/**
 *.vsix
 .gitignore
 .eslintrc.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Viewstor are documented here. Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.2.4] — 2026-03-30
+
+### Fixed
+- Extension crash on startup: `ssh2` native module not included in `.vsix` package ([#38](https://github.com/Siyet/viewstor/issues/38))
+- E2E tests for `getCompletions` updated to match structured `CompletionItem[]` return type
+
+### Added
+- Output channel "Viewstor" with activation error notification and "Show Logs" button ([#39](https://github.com/Siyet/viewstor/issues/39))
+- E2E tests job in CI pipeline
+
 ## [0.2.3] — 2026-03-30
 
 ### Added

--- a/l10n/bundle.l10n.ar.json
+++ b/l10n/bundle.l10n.ar.json
@@ -62,5 +62,7 @@
   "Don't show again": "عدم الإظهار مجددًا",
   "Clear all query history?": "مسح كل سجل الاستعلامات؟",
   "Clear": "مسح",
-  "Pinned": "مثبتة"
+  "Pinned": "مثبتة",
+  "Show Logs": "عرض السجلات",
+  "Viewstor failed to activate: {0}": "فشل تنشيط Viewstor: {0}"
 }

--- a/l10n/bundle.l10n.bn.json
+++ b/l10n/bundle.l10n.bn.json
@@ -62,5 +62,7 @@
   "Don't show again": "আর দেখাবেন না",
   "Clear all query history?": "সমস্ত কোয়েরি ইতিহাস মুছবেন?",
   "Clear": "মুছুন",
-  "Pinned": "পিন করা"
+  "Pinned": "পিন করা",
+  "Show Logs": "লগ দেখুন",
+  "Viewstor failed to activate: {0}": "Viewstor সক্রিয় করতে ব্যর্থ: {0}"
 }

--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -62,5 +62,7 @@
   "Don't show again": "Nicht mehr anzeigen",
   "Clear all query history?": "Gesamten Abfrageverlauf löschen?",
   "Clear": "Löschen",
-  "Pinned": "Angeheftet"
+  "Pinned": "Angeheftet",
+  "Show Logs": "Protokolle anzeigen",
+  "Viewstor failed to activate: {0}": "Viewstor konnte nicht aktiviert werden: {0}"
 }

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -62,5 +62,7 @@
   "Don't show again": "No volver a mostrar",
   "Clear all query history?": "¿Borrar todo el historial de consultas?",
   "Clear": "Borrar",
-  "Pinned": "Fijadas"
+  "Pinned": "Fijadas",
+  "Show Logs": "Ver registros",
+  "Viewstor failed to activate: {0}": "Viewstor no pudo activarse: {0}"
 }

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -62,5 +62,7 @@
   "Don't show again": "Ne plus afficher",
   "Clear all query history?": "Effacer tout l'historique des requêtes ?",
   "Clear": "Effacer",
-  "Pinned": "Épinglées"
+  "Pinned": "Épinglées",
+  "Show Logs": "Voir les journaux",
+  "Viewstor failed to activate: {0}": "Échec de l'activation de Viewstor : {0}"
 }

--- a/l10n/bundle.l10n.hi.json
+++ b/l10n/bundle.l10n.hi.json
@@ -62,5 +62,7 @@
   "Don't show again": "दोबारा न दिखाएँ",
   "Clear all query history?": "सभी क्वेरी इतिहास साफ़ करें?",
   "Clear": "साफ़ करें",
-  "Pinned": "पिन किए गए"
+  "Pinned": "पिन किए गए",
+  "Show Logs": "लॉग दिखाएँ",
+  "Viewstor failed to activate: {0}": "Viewstor सक्रिय करने में विफल: {0}"
 }

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -62,5 +62,7 @@
   "Don't show again": "今後表示しない",
   "Clear all query history?": "すべてのクエリ履歴をクリアしますか？",
   "Clear": "クリア",
-  "Pinned": "固定済み"
+  "Pinned": "固定済み",
+  "Show Logs": "ログを表示",
+  "Viewstor failed to activate: {0}": "Viewstor のアクティベーションに失敗しました: {0}"
 }

--- a/l10n/bundle.l10n.ko.json
+++ b/l10n/bundle.l10n.ko.json
@@ -62,5 +62,7 @@
   "Don't show again": "다시 표시하지 않기",
   "Clear all query history?": "모든 쿼리 기록을 지우시겠습니까?",
   "Clear": "지우기",
-  "Pinned": "고정됨"
+  "Pinned": "고정됨",
+  "Show Logs": "로그 보기",
+  "Viewstor failed to activate: {0}": "Viewstor 활성화 실패: {0}"
 }

--- a/l10n/bundle.l10n.pt-br.json
+++ b/l10n/bundle.l10n.pt-br.json
@@ -62,5 +62,7 @@
   "Don't show again": "Não mostrar novamente",
   "Clear all query history?": "Limpar todo o histórico de consultas?",
   "Clear": "Limpar",
-  "Pinned": "Fixadas"
+  "Pinned": "Fixadas",
+  "Show Logs": "Ver logs",
+  "Viewstor failed to activate: {0}": "Falha ao ativar o Viewstor: {0}"
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -62,5 +62,7 @@
   "Don't show again": "Больше не показывать",
   "Clear all query history?": "Очистить всю историю запросов?",
   "Clear": "Очистить",
-  "Pinned": "Закреплённые"
+  "Pinned": "Закреплённые",
+  "Show Logs": "Показать логи",
+  "Viewstor failed to activate: {0}": "Viewstor не удалось активировать: {0}"
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -62,5 +62,7 @@
   "Don't show again": "不再显示",
   "Clear all query history?": "清除所有查询历史？",
   "Clear": "清除",
-  "Pinned": "已固定"
+  "Pinned": "已固定",
+  "Show Logs": "显示日志",
+  "Viewstor failed to activate: {0}": "Viewstor 激活失败: {0}"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "viewstor",
   "displayName": "Viewstor",
   "description": "%extension.description%",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "Siyet",
   "license": "AGPL-3.0",
   "icon": "resources/icon.png",
@@ -450,6 +450,8 @@
     ]
   },
   "devDependencies": {
+    "@clickhouse/client": "^0.2.0",
+    "@modelcontextprotocol/sdk": "^1.28.0",
     "@types/node": "^20.11.0",
     "@types/pg": "^8.20.0",
     "@types/ssh2": "^1.15.5",
@@ -460,6 +462,8 @@
     "copy-webpack-plugin": "^12.0.0",
     "css-loader": "^6.10.0",
     "eslint": "^8.56.0",
+    "ioredis": "^5.3.0",
+    "pg": "^8.11.0",
     "style-loader": "^3.3.4",
     "testcontainers": "^11.13.0",
     "ts-loader": "^9.5.0",
@@ -469,10 +473,6 @@
     "webpack-cli": "^5.1.0"
   },
   "dependencies": {
-    "@clickhouse/client": "^0.2.0",
-    "@modelcontextprotocol/sdk": "^1.28.0",
-    "ioredis": "^5.3.0",
-    "pg": "^8.11.0",
     "ssh2": "^1.17.0"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,77 +14,98 @@ import { registerCommands } from './commands';
 import { registerChatParticipant } from './chat/participant';
 
 let connectionManager: ConnectionManager;
+let outputChannel: vscode.OutputChannel;
 
 export function activate(context: vscode.ExtensionContext) {
-  connectionManager = new ConnectionManager(context);
+  outputChannel = vscode.window.createOutputChannel('Viewstor');
+  context.subscriptions.push(outputChannel);
 
-  const connectionTreeProvider = new ConnectionTreeProvider(connectionManager);
-  const queryHistoryProvider = new QueryHistoryProvider(context);
-  const queryEditorProvider = new QueryEditorProvider(connectionManager);
-  const resultPanelManager = new ResultPanelManager(context);
-  const connectionFormPanel = new ConnectionFormPanel(context, connectionManager);
-  const folderFormPanel = new FolderFormPanel(context, connectionManager);
+  try {
+    connectionManager = new ConnectionManager(context);
 
-  const connectionTreeView = vscode.window.createTreeView('viewstor.connections', {
-    treeDataProvider: connectionTreeProvider,
-    showCollapseAll: true,
-    dragAndDropController: connectionTreeProvider,
-  });
+    const connectionTreeProvider = new ConnectionTreeProvider(connectionManager);
+    const queryHistoryProvider = new QueryHistoryProvider(context);
+    const queryEditorProvider = new QueryEditorProvider(connectionManager);
+    const resultPanelManager = new ResultPanelManager(context);
+    const connectionFormPanel = new ConnectionFormPanel(context, connectionManager);
+    const folderFormPanel = new FolderFormPanel(context, connectionManager);
 
-  vscode.window.createTreeView('viewstor.queryHistory', {
-    treeDataProvider: queryHistoryProvider,
-  });
+    const connectionTreeView = vscode.window.createTreeView('viewstor.connections', {
+      treeDataProvider: connectionTreeProvider,
+      showCollapseAll: true,
+      dragAndDropController: connectionTreeProvider,
+    });
 
-  registerCommands(context, {
-    connectionManager,
-    connectionTreeProvider,
-    queryHistoryProvider,
-    queryEditorProvider,
-    resultPanelManager,
-    connectionFormPanel,
-    folderFormPanel,
-  });
+    vscode.window.createTreeView('viewstor.queryHistory', {
+      treeDataProvider: queryHistoryProvider,
+    });
 
-  // MCP-compatible commands for AI agent integration
-  registerMcpCommands(context, connectionManager);
+    registerCommands(context, {
+      connectionManager,
+      connectionTreeProvider,
+      queryHistoryProvider,
+      queryEditorProvider,
+      resultPanelManager,
+      connectionFormPanel,
+      folderFormPanel,
+    });
 
-  // Copilot Chat participant (@viewstor)
-  registerChatParticipant(context, connectionManager, queryEditorProvider);
+    // MCP-compatible commands for AI agent integration
+    registerMcpCommands(context, connectionManager);
 
-  // SQL autocomplete from DB schema
-  const completionProvider = new SqlCompletionProvider(connectionManager, queryEditorProvider);
-  // Index hints (missing index warnings)
-  const indexHintProvider = new IndexHintProvider(connectionManager, queryEditorProvider);
-  indexHintProvider.register(context);
-  // SQL diagnostics (non-existent tables/columns)
-  const sqlDiagnosticProvider = new SqlDiagnosticProvider(connectionManager, queryEditorProvider);
-  sqlDiagnosticProvider.register(context);
-  // Status bar: Report Issue button (visible only when Viewstor is active)
-  const reportBtn = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 0);
-  reportBtn.text = '$(github) Viewstor: bug report';
-  reportBtn.tooltip = 'Report an issue on GitHub';
-  reportBtn.command = 'viewstor.reportIssue';
+    // Copilot Chat participant (@viewstor)
+    registerChatParticipant(context, connectionManager, queryEditorProvider);
 
-  function updateReportBtnVisibility() {
-    const editor = vscode.window.activeTextEditor;
-    const isSqlEditor = editor?.document.languageId === 'sql' || editor?.document.uri.scheme === 'viewstor';
-    // Show when: tree visible, SQL editor active, OR no text editor active (webview panel like data table/results)
-    const isViewstorContext = connectionTreeView.visible || isSqlEditor || !editor;
-    if (isViewstorContext) reportBtn.show();
-    else reportBtn.hide();
+    // SQL autocomplete from DB schema
+    const completionProvider = new SqlCompletionProvider(connectionManager, queryEditorProvider);
+    // Index hints (missing index warnings)
+    const indexHintProvider = new IndexHintProvider(connectionManager, queryEditorProvider);
+    indexHintProvider.register(context);
+    // SQL diagnostics (non-existent tables/columns)
+    const sqlDiagnosticProvider = new SqlDiagnosticProvider(connectionManager, queryEditorProvider);
+    sqlDiagnosticProvider.register(context);
+    // Status bar: Report Issue button (visible only when Viewstor is active)
+    const reportBtn = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 0);
+    reportBtn.text = '$(github) Viewstor: bug report';
+    reportBtn.tooltip = 'Report an issue on GitHub';
+    reportBtn.command = 'viewstor.reportIssue';
+
+    const updateReportBtnVisibility = () => {
+      const editor = vscode.window.activeTextEditor;
+      const isSqlEditor = editor?.document.languageId === 'sql' || editor?.document.uri.scheme === 'viewstor';
+      // Show when: tree visible, SQL editor active, OR no text editor active (webview panel like data table/results)
+      const isViewstorContext = connectionTreeView.visible || isSqlEditor || !editor;
+      if (isViewstorContext) reportBtn.show();
+      else reportBtn.hide();
+    };
+    updateReportBtnVisibility();
+    connectionTreeView.onDidChangeVisibility(() => updateReportBtnVisibility());
+    vscode.window.onDidChangeActiveTextEditor(() => updateReportBtnVisibility());
+
+    context.subscriptions.push(
+      vscode.languages.registerCompletionItemProvider('sql', completionProvider, '.'),
+      connectionTreeView,
+      reportBtn,
+    );
+
+    // "What's New" notification after update
+    showWhatsNew(context);
+
+    outputChannel.appendLine(`Viewstor activated (v${vscode.extensions.getExtension('Siyet.viewstor')?.packageJSON.version ?? '?'})`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const stack = err instanceof Error ? err.stack : undefined;
+    outputChannel.appendLine(`[ERROR] Activation failed: ${message}`);
+    if (stack) outputChannel.appendLine(stack);
+    const showLogs = vscode.l10n.t('Show Logs');
+    vscode.window.showErrorMessage(
+      vscode.l10n.t('Viewstor failed to activate: {0}', message),
+      showLogs,
+    ).then(action => {
+      if (action === showLogs) outputChannel.show();
+    });
+    throw err;
   }
-  updateReportBtnVisibility();
-  connectionTreeView.onDidChangeVisibility(() => updateReportBtnVisibility());
-  vscode.window.onDidChangeActiveTextEditor(() => updateReportBtnVisibility());
-
-  context.subscriptions.push(
-    vscode.languages.registerCompletionItemProvider('sql', completionProvider, '.'),
-    connectionTreeView,
-    reportBtn,
-  );
-
-  // "What's New" notification after update
-  showWhatsNew(context);
 }
 
 function showWhatsNew(context: vscode.ExtensionContext) {

--- a/src/test/e2e/clickhouse.e2e.test.ts
+++ b/src/test/e2e/clickhouse.e2e.test.ts
@@ -152,8 +152,9 @@ describeIf(isDockerAvailable)('ClickHouse Driver E2E', () => {
 
   it('getCompletions returns table names', async () => {
     const completions = await driver.getCompletions!();
-    expect(completions).toContain('events');
-    expect(completions).toContain('metrics');
+    const labels = completions.map(c => c.label);
+    expect(labels).toContain('events');
+    expect(labels).toContain('metrics');
   });
 
   it('getTableData with orderBy sorts results', async () => {

--- a/src/test/e2e/postgres.e2e.test.ts
+++ b/src/test/e2e/postgres.e2e.test.ts
@@ -240,8 +240,9 @@ describeIf(isDockerAvailable)('PostgreSQL Driver E2E', () => {
 
   it('getCompletions returns table and column names', async () => {
     const completions = await driver.getCompletions!();
-    expect(completions).toContain('users');
-    expect(completions).toContain('orders');
+    const labels = completions.map(c => c.label);
+    expect(labels).toContain('users');
+    expect(labels).toContain('orders');
   });
 
   it('getTableData for enum columns includes enumValues', async () => {


### PR DESCRIPTION
## Summary
- Fix extension crash on startup: `ssh2` native module not included in `.vsix` package (#38)
- Add OutputChannel "Viewstor" with activation error notification and "Show Logs" button (#39)
- Fix e2e tests for `getCompletions` (structured `CompletionItem[]` return type)
- Add E2E tests job to CI pipeline

## Changes
- Moved webpack-bundled deps (`pg`, `ioredis`, `@clickhouse/client`, `@modelcontextprotocol/sdk`) to `devDependencies`
- Removed `node_modules/**` from `.vscodeignore` — `vsce package` now naturally includes production deps (`ssh2` + transitive tree)
- Wrapped `activate()` in try/catch with error notification + output channel logging
- Added l10n translations for new strings (11 languages)

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 42/42 unit tests pass
- [x] `npm run test:e2e` — 50/50 e2e tests pass
- [x] `npm run build` — production build succeeds
- [x] `vsce ls` confirms `node_modules/ssh2/**` included in package

🤖 Generated with [Claude Code](https://claude.com/claude-code)