### PR TITLE
release: v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to Viewstor are documented here. Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.2.6] — 2026-03-30
+
+### Added
+- **Native MCP server registration** — extension registers MCP server via `mcpServerDefinitionProviders`, auto-discovered by Copilot/Cursor without any config ([#43](https://github.com/Siyet/viewstor/issues/43))
+- **Resizable columns** — drag column header right edge to resize ([#44](https://github.com/Siyet/viewstor/issues/44))
+- **Add row** — insert a new row with DEFAULT values from the table data toolbar ([#45](https://github.com/Siyet/viewstor/issues/45))
+- **Delete rows** — delete selected rows by PK, from toolbar (enabled on selection) and right-click context menu ([#45](https://github.com/Siyet/viewstor/issues/45))
+- **Refresh button** (↻) in toolbar and footer — re-run current query or reload table data
+- **Inline table icon** — click eye icon next to table/view name in tree to open data
+- **JSON editing via native VS Code tab** — double-click JSON cell opens `.json` file beside with full syntax highlighting, Ctrl+S applies value back to cell
+- **SQL confirmation via native VS Code tab** — Save Changes / Insert / Delete opens `.sql` file with ▶ Play button in editor title, Ctrl+Enter or ▶ to execute, Ctrl+S pins query in history
+- **Type-aware SQL generation** — numeric PKs without quotes (`WHERE "id" = 244`), boolean as `TRUE`/`FALSE`, `::jsonb`/`::json` casts
+- Footer toolbar with all action buttons (refresh, export, add/delete row, save/discard)
+- SQL builder utilities extracted to `src/utils/queryHelpers.ts` with 96 unit tests
+- 8 new e2e tests: multi-schema dedup, numeric PK, JSONB/JSON cast, boolean update, DELETE, INSERT DEFAULT, multi-database
+
+### Changed
+- Custom SQL query and pagination update only the table grid, not the entire page — SQL input, scroll position preserved
+- JSON and SQL editing moved from webview popups to native VS Code editor tabs with full syntax highlighting, IntelliSense, and standard keybindings
+
+### Fixed
+- SQL editor queries on secondary databases in multi-DB connections now execute against the correct database, not the main one
+- Multi-DB driver caching with auto-reconnect — no more temporary drivers discarded after schema fetch
+- JSON inline edits generated `[object Object]` in UPDATE SQL — now properly serialized via `JSON.stringify`
+- `+ Row` / `− Row` buttons disappeared after changing SQL query in table data view
+
 ## [0.2.5] — 2026-03-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,11 @@ Usage in Claude Code config:
 
 `src/services/importService.ts` — parseDBeaver (data-sources.json), parseDataGrip (dataSources.xml, regex XML), parsePgAdmin (servers.json). Maps providers to DatabaseType, skips unsupported with warnings. No password import.
 
+### Utilities
+`src/utils/queryHelpers.ts` — pure functions for SQL generation and error enhancement: `levenshtein`, `parseTablesFromQuery`, `enhanceColumnError`, `buildUpdateSql`, `buildDeleteSql`, `buildInsertDefaultSql`, `quoteTable`, `sqlValue`. All vscode-independent, fully unit-tested.
+
 ### Commands
-`src/commands/index.ts` — all `viewstor.*` commands. Notable: `_fetchPage` (server-side pagination), `_exportAllData` (fetches up to 100k rows), `_cancelQuery`, `_refreshCount` (exact COUNT), `reportIssue` (GitHub issue with env info).
+`src/commands/index.ts` — all `viewstor.*` commands. Notable: `_fetchPage` (server-side pagination), `_exportAllData` (fetches up to 100k rows), `_cancelQuery`, `_refreshCount` (exact COUNT), `_insertRow` (INSERT with DEFAULT), `_deleteRows` (DELETE by PK with confirmation), `reportIssue` (GitHub issue with env info). All commands support `databaseName` parameter for multi-DB connections.
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ Mark a connection or an entire folder as read-only. Child connections inherit th
 
 - Server-side pagination (50 / 100 / 500 / 1000 rows)
 - Estimated row count from statistics, exact count via refresh
-- Inline editing with PK-based `UPDATE` (disabled in read-only)
+- Inline editing with PK-based `UPDATE`, type-aware SQL (numeric PKs without quotes, `::jsonb` cast)
+- **Add / delete rows** — insert with DEFAULT values, delete from toolbar or right-click context menu
+- **Resizable columns** — drag column header edge to adjust width
+- **Refresh button** — re-run current query without page reload
 - Column sorting (shift-click for multi-column)
 - Cell selection with drag, Shift+Click range, resize handle
 - Search with `Ctrl+F`, Enter to cycle matches

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "viewstor",
   "displayName": "Viewstor",
   "description": "%extension.description%",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "publisher": "Siyet",
   "license": "AGPL-3.0",
   "icon": "resources/icon.png",
@@ -49,6 +49,12 @@
     "package": "vsce package"
   },
   "contributes": {
+    "mcpServerDefinitionProviders": [
+      {
+        "id": "viewstor.mcpServer",
+        "label": "Viewstor MCP"
+      }
+    ],
     "chatParticipants": [
       {
         "id": "viewstor.chat",
@@ -149,12 +155,19 @@
       {
         "command": "viewstor.showTableData",
         "title": "%command.showTableData%",
-        "category": "Viewstor"
+        "category": "Viewstor",
+        "icon": "$(open-preview)"
       },
       {
         "command": "viewstor.showDDL",
         "title": "%command.showDDL%",
         "category": "Viewstor"
+      },
+      {
+        "command": "viewstor.executeTempSql",
+        "title": "Execute SQL",
+        "category": "Viewstor",
+        "icon": "$(play)"
       },
       {
         "command": "viewstor.createFolder",
@@ -256,6 +269,13 @@
       }
     ],
     "menus": {
+      "editor/title": [
+        {
+          "command": "viewstor.executeTempSql",
+          "when": "viewstor.isTempSqlFile",
+          "group": "navigation"
+        }
+      ],
       "view/title": [
         {
           "command": "viewstor.addConnection",
@@ -279,6 +299,11 @@
         }
       ],
       "view/item/context": [
+        {
+          "command": "viewstor.showTableData",
+          "when": "view == viewstor.connections && viewItem =~ /^(table|view)$/",
+          "group": "inline"
+        },
         {
           "command": "viewstor.refreshConnection",
           "when": "view == viewstor.connections && viewItem == connection-connected",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,7 +9,8 @@ import { FolderFormPanel } from '../views/folderForm';
 import { SortColumn, QueryResult, QueryColumn, QueryHistoryEntry } from '../types/query';
 import { ExportService } from '../services/exportService';
 import { ImportSource, parseImportFile } from '../services/importService';
-import { enhanceColumnError } from '../utils/queryHelpers';
+import { enhanceColumnError, buildUpdateSql, buildDeleteSql, buildInsertDefaultSql } from '../utils/queryHelpers';
+import { TempFileManager } from '../services/tempFileManager';
 
 interface CommandContext {
   connectionManager: ConnectionManager;
@@ -20,6 +21,7 @@ interface CommandContext {
   connectionFormPanel: ConnectionFormPanel;
   folderFormPanel: FolderFormPanel;
   outputChannel: vscode.OutputChannel;
+  tempFileManager: TempFileManager;
 }
 
 let queryResultCounter = 0;
@@ -27,8 +29,51 @@ const historyDocMap = new Map<string, string>(); // entry.id → doc URI
 let _outputChannel: vscode.OutputChannel;
 
 export function registerCommands(context: vscode.ExtensionContext, ctx: CommandContext) {
-  const { connectionManager, connectionTreeProvider, queryHistoryProvider, queryEditorProvider, resultPanelManager, connectionFormPanel, folderFormPanel, outputChannel } = ctx;
+  const { connectionManager, connectionTreeProvider, queryHistoryProvider, queryEditorProvider, resultPanelManager, connectionFormPanel, folderFormPanel, outputChannel, tempFileManager } = ctx;
   _outputChannel = outputChannel;
+
+  // Wire up TempFileManager callbacks
+  tempFileManager.setOnSqlExecuted(async (sqlCtx, sql) => {
+    const driver = sqlCtx.databaseName
+      ? await connectionManager.getDriverForDatabase(sqlCtx.connectionId, sqlCtx.databaseName)
+      : connectionManager.getDriver(sqlCtx.connectionId);
+    if (!driver) return;
+    const statements = sql.split(';').map(s => s.trim()).filter(Boolean);
+    const errors: string[] = [];
+    for (const stmt of statements) {
+      const result = await driver.execute(stmt);
+      if (result.error) errors.push(result.error);
+    }
+    if (errors.length > 0) {
+      logAndShowError(errors.join('; '));
+    } else {
+      const count = statements.length;
+      if (sqlCtx.context === 'deleteRows') {
+        vscode.window.showInformationMessage(vscode.l10n.t('{0} row(s) deleted.', count));
+      } else if (sqlCtx.context === 'insertRow') {
+        vscode.window.showInformationMessage(vscode.l10n.t('Row inserted.'));
+      } else {
+        vscode.window.showInformationMessage(vscode.l10n.t('{0} row(s) saved.', count));
+      }
+      if (sqlCtx.panelKey) {
+        resultPanelManager.postMessage(sqlCtx.panelKey, { type: 'rerunQuery' });
+      }
+    }
+  });
+
+  tempFileManager.setOnSqlSaved(async (sqlCtx, sql) => {
+    const state = connectionManager.get(sqlCtx.connectionId);
+    await queryHistoryProvider.addEntry({
+      id: Date.now().toString(36) + Math.random().toString(36).substring(2, 8),
+      connectionId: sqlCtx.connectionId,
+      connectionName: state?.config.name || '',
+      query: sql,
+      executedAt: Date.now(),
+      executionTimeMs: 0,
+      rowCount: 0,
+      pinned: true,
+    });
+  });
 
   context.subscriptions.push(
     vscode.workspace.registerTextDocumentContentProvider('viewstor', new QueryDocumentProvider())
@@ -101,12 +146,22 @@ export function registerCommands(context: vscode.ExtensionContext, ctx: CommandC
           return;
         }
       }
-      await queryEditorProvider.openNewQuery(item.connectionId);
+      await queryEditorProvider.openNewQuery(item.connectionId, item.databaseName);
+    }),
+
+    vscode.commands.registerCommand('viewstor.executeTempSql', async () => {
+      await tempFileManager.executeSqlFromActiveEditor();
     }),
 
     vscode.commands.registerCommand('viewstor.runQuery', async () => {
       const editor = vscode.window.activeTextEditor;
       if (!editor) return;
+
+      // If this is a temp SQL file (from Save Changes / Insert / Delete), execute it
+      if (tempFileManager.isTempSqlFile(editor.document.uri)) {
+        await tempFileManager.executeSqlFromActiveEditor();
+        return;
+      }
 
       const connectionId = queryEditorProvider.getConnectionIdFromUri(editor.document.uri);
       if (!connectionId) {
@@ -114,7 +169,10 @@ export function registerCommands(context: vscode.ExtensionContext, ctx: CommandC
         return;
       }
 
-      const driver = connectionManager.getDriver(connectionId);
+      const databaseName = queryEditorProvider.getDatabaseNameFromUri(editor.document.uri);
+      const driver = databaseName
+        ? await connectionManager.getDriverForDatabase(connectionId, databaseName)
+        : connectionManager.getDriver(connectionId);
       if (!driver) {
         vscode.window.showWarningMessage(vscode.l10n.t('Not connected. Please connect first.'));
         return;
@@ -344,9 +402,6 @@ export function registerCommands(context: vscode.ExtensionContext, ctx: CommandC
       if (!driver) return;
 
       try {
-        const tableInfo = await driver.getTableInfo(tableName, schema);
-        const pkColumns = tableInfo.columns.filter(c => c.isPrimaryKey).map(c => c.name);
-
         let totalRowCount: number | undefined;
         let isEstimatedCount = false;
         if (driver.getEstimatedRowCount) {
@@ -369,12 +424,16 @@ export function registerCommands(context: vscode.ExtensionContext, ctx: CommandC
           return;
         }
         const state = connectionManager.get(connectionId);
-        const title = `${tableName} — ${state?.config.name}`;
-        const color = connectionManager.getConnectionColor(connectionId);
-        const readonly = connectionManager.isConnectionReadonly(connectionId);
-        resultPanelManager.show(result, title, {
-          connectionId, tableName, schema, pkColumns, color, orderBy, readonly,
-          pageSize, currentPage: page, totalRowCount, isEstimatedCount, databaseName,
+        const panelKey = `${tableName} — ${state?.config.name}`;
+        resultPanelManager.postMessage(panelKey, {
+          type: 'updateData',
+          columns: result.columns,
+          rows: result.rows,
+          rowCount: totalRowCount ?? result.rowCount,
+          executionTimeMs: result.executionTimeMs,
+          currentPage: page,
+          totalPages: totalRowCount ? Math.max(1, Math.ceil(totalRowCount / pageSize)) : 1,
+          isEstimatedCount,
         });
       } catch (err) {
         logAndShowError(vscode.l10n.t('Failed to load data: {0}', err instanceof Error ? err.message : String(err)));
@@ -450,61 +509,22 @@ export function registerCommands(context: vscode.ExtensionContext, ctx: CommandC
       if (!driver) return;
 
       // Build all SQL statements
-      const statements: string[] = [];
-      for (const edit of edits) {
-        const setClauses = Object.entries(edit.changes)
-          .map(([col, val]) => `"${col}" = ${val === null ? 'NULL' : `'${String(val).replace(/'/g, '\'\'')}'`}`)
-          .join(', ');
-        const whereClauses = pkColumns
-          .map(pk => `"${pk}" = '${String(edit.pkValues[pk]).replace(/'/g, '\'\'')}'`)
-          .join(' AND ');
-        const quoted = schema ? `"${schema}"."${tableName}"` : `"${tableName}"`;
-        statements.push(`UPDATE ${quoted} SET ${setClauses} WHERE ${whereClauses};`);
-      }
+      const statements = edits.map(edit => buildUpdateSql(tableName, schema, pkColumns, edit) + ';');
 
       const confirmEdits = vscode.workspace.getConfiguration('viewstor').get<boolean>('confirmEdits', true);
 
       if (confirmEdits) {
         const fullSql = statements.join('\n');
-        const doc = await vscode.workspace.openTextDocument({ content: fullSql, language: 'sql' });
-        const editor = await vscode.window.showTextDocument(doc, { preview: false });
-
-        const executeBtn = vscode.l10n.t('Execute');
-        const dontAskBtn = vscode.l10n.t('Don\'t ask again');
-        const cancelBtn = vscode.l10n.t('Cancel');
-        const action = await vscode.window.showWarningMessage(
-          vscode.l10n.t('Execute {0} UPDATE statement(s)?', statements.length),
-          executeBtn, dontAskBtn, cancelBtn
-        );
-
-        if (action === dontAskBtn) {
-          await vscode.workspace.getConfiguration('viewstor').update('confirmEdits', false, vscode.ConfigurationTarget.Global);
-        }
-
-        if (action !== executeBtn && action !== dontAskBtn) {
-          return;
-        }
-
-        // Re-read from editor in case user edited the SQL
-        const editedSql = editor.document.getText();
-        const editedStatements = editedSql.split(';').map(s => s.trim()).filter(Boolean);
-
-        const errors: string[] = [];
-        for (const sql of editedStatements) {
-          const result = await driver.execute(sql);
-          if (result.error) errors.push(result.error);
-        }
-
-        if (errors.length > 0) {
-          logAndShowError(vscode.l10n.t('Save errors: {0}', errors.join('; ')));
-        } else {
-          vscode.window.showInformationMessage(vscode.l10n.t('{0} row(s) saved.', editedStatements.length));
-        }
+        const state = connectionManager.get(connectionId);
+        const panelKey = `${tableName} — ${state?.config.name}`;
+        await tempFileManager.openSqlEditor(fullSql, {
+          panelKey, connectionId, tableName, databaseName, context: 'saveEdits',
+        });
+        return;
       } else {
-        // Execute without confirmation
         const errors: string[] = [];
         for (const sql of statements) {
-          const result = await driver.execute(sql);
+          const result = await driver.execute(sql.replace(/;+\s*$/, ''));
           if (result.error) errors.push(result.error);
         }
 
@@ -516,7 +536,53 @@ export function registerCommands(context: vscode.ExtensionContext, ctx: CommandC
       }
     }),
 
-    vscode.commands.registerCommand('viewstor._runCustomTableQuery', async (connectionId: string, tableName: string, schema: string | undefined, query: string, pageSize: number, databaseName?: string) => {
+    vscode.commands.registerCommand('viewstor._insertRow', async (connectionId: string, tableName: string, schema: string | undefined, _row: Record<string, unknown>, databaseName?: string) => {
+      const driver = databaseName
+        ? await connectionManager.getDriverForDatabase(connectionId, databaseName)
+        : connectionManager.getDriver(connectionId);
+      if (!driver) return;
+
+      // Get column info to build INSERT with DEFAULT values
+      const tableInfo = await driver.getTableInfo(tableName, schema);
+      const colNames = tableInfo.columns.map(c => c.name);
+      const sql = buildInsertDefaultSql(tableName, schema, colNames) + ';';
+
+      const confirmEdits = vscode.workspace.getConfiguration('viewstor').get<boolean>('confirmEdits', true);
+      if (confirmEdits) {
+        const state = connectionManager.get(connectionId);
+        const panelKey = `${tableName} — ${state?.config.name}`;
+        await tempFileManager.openSqlEditor(sql, {
+          panelKey, connectionId, tableName, databaseName, context: 'insertRow',
+        });
+        return;
+      }
+
+      const result = await driver.execute(sql.replace(/;+\s*$/, ''));
+      if (result.error) {
+        logAndShowError(vscode.l10n.t('Insert failed: {0}', result.error));
+      } else {
+        vscode.window.showInformationMessage(vscode.l10n.t('Row inserted.'));
+        const state = connectionManager.get(connectionId);
+        resultPanelManager.postMessage(`${tableName} — ${state?.config.name}`, { type: 'rerunQuery' });
+      }
+    }),
+
+    vscode.commands.registerCommand('viewstor._deleteRows', async (connectionId: string, tableName: string, schema: string | undefined, pkColumns: string[], rows: Record<string, unknown>[], databaseName?: string, pkTypes?: Record<string, string>) => {
+      const driver = databaseName
+        ? await connectionManager.getDriverForDatabase(connectionId, databaseName)
+        : connectionManager.getDriver(connectionId);
+      if (!driver) return;
+
+      const statements = rows.map(pkValues => buildDeleteSql(tableName, schema, pkColumns, pkValues, pkTypes) + ';');
+
+      const state = connectionManager.get(connectionId);
+      const panelKey = `${tableName} — ${state?.config.name}`;
+      await tempFileManager.openSqlEditor(statements.join('\n'), {
+        panelKey, connectionId, tableName, databaseName, context: 'deleteRows',
+      });
+    }),
+
+    vscode.commands.registerCommand('viewstor._runCustomTableQuery', async (connectionId: string, tableName: string, _schema: string | undefined, query: string, pageSize: number, databaseName?: string) => {
       const driver = databaseName
         ? await connectionManager.getDriverForDatabase(connectionId, databaseName)
         : connectionManager.getDriver(connectionId);
@@ -543,15 +609,13 @@ export function registerCommands(context: vscode.ExtensionContext, ctx: CommandC
           return;
         }
         const state = connectionManager.get(connectionId);
-        const title = `${tableName} — ${state?.config.name}`;
-        const color = connectionManager.getConnectionColor(connectionId);
-        const readonly = connectionManager.isConnectionReadonly(connectionId);
-        resultPanelManager.show(result, title, {
-          connectionId, tableName, schema, color, readonly,
-          pageSize, currentPage: 0,
-          totalRowCount: result.rowCount,
-          isEstimatedCount: false,
-          query,
+        const panelKey = `${tableName} — ${state?.config.name}`;
+        resultPanelManager.postMessage(panelKey, {
+          type: 'updateData',
+          columns: result.columns,
+          rows: result.rows,
+          rowCount: result.rowCount,
+          executionTimeMs: result.executionTimeMs,
         });
       } catch (err) {
         const shortQ = query.length > 255 ? query.substring(0, 255) + '...' : query;
@@ -568,6 +632,38 @@ export function registerCommands(context: vscode.ExtensionContext, ctx: CommandC
           vscode.window.showInformationMessage(vscode.l10n.t('Query cancelled.'));
         } catch (err) {
           vscode.window.showWarningMessage(vscode.l10n.t('Cancel failed: {0}', err instanceof Error ? err.message : String(err)));
+        }
+      }
+    }),
+
+    vscode.commands.registerCommand('viewstor._executeSqlStatements', async (connectionId: string, sql: string, context: string, tableName?: string, databaseName?: string) => {
+      const driver = databaseName
+        ? await connectionManager.getDriverForDatabase(connectionId, databaseName)
+        : connectionManager.getDriver(connectionId);
+      if (!driver) return;
+
+      const statements = sql.split(';').map(s => s.trim()).filter(Boolean);
+      const errors: string[] = [];
+      for (const stmt of statements) {
+        const result = await driver.execute(stmt);
+        if (result.error) errors.push(result.error);
+      }
+
+      if (errors.length > 0) {
+        logAndShowError(errors.join('; '));
+      } else {
+        const count = statements.length;
+        if (context === 'deleteRows') {
+          vscode.window.showInformationMessage(vscode.l10n.t('{0} row(s) deleted.', count));
+        } else if (context === 'insertRow') {
+          vscode.window.showInformationMessage(vscode.l10n.t('Row inserted.'));
+        } else {
+          vscode.window.showInformationMessage(vscode.l10n.t('{0} row(s) saved.', count));
+        }
+        // Refresh the panel
+        if (tableName) {
+          const state = connectionManager.get(connectionId);
+          resultPanelManager.postMessage(`${tableName} — ${state?.config.name}`, { type: 'rerunQuery' });
         }
       }
     }),

--- a/src/editors/queryEditor.ts
+++ b/src/editors/queryEditor.ts
@@ -3,15 +3,20 @@ import { ConnectionManager } from '../connections/connectionManager';
 
 const SCHEME = 'viewstor';
 
-// Map to track connectionId for untitled documents
-const connectionMap = new Map<string, string>();
+interface QueryEditorContext {
+  connectionId: string;
+  databaseName?: string;
+}
+
+// Map to track connectionId + databaseName for untitled documents
+const connectionMap = new Map<string, QueryEditorContext>();
 
 export class QueryEditorProvider {
   private queryCounter = 0;
 
   constructor(private readonly connectionManager: ConnectionManager) {}
 
-  async openNewQuery(connectionId: string) {
+  async openNewQuery(connectionId: string, databaseName?: string) {
     const state = this.connectionManager.get(connectionId);
     if (!state) {
       throw new Error('Connection not found');
@@ -26,7 +31,7 @@ export class QueryEditorProvider {
     });
 
     // Track connection by document URI
-    connectionMap.set(doc.uri.toString(), connectionId);
+    connectionMap.set(doc.uri.toString(), { connectionId, databaseName });
 
     await vscode.window.showTextDocument(doc, {
       viewColumn: vscode.ViewColumn.One,
@@ -35,9 +40,8 @@ export class QueryEditorProvider {
   }
 
   getConnectionIdFromUri(uri: vscode.Uri): string | undefined {
-    // Check untitled document map first
     const mapped = connectionMap.get(uri.toString());
-    if (mapped) return mapped;
+    if (mapped) return mapped.connectionId;
 
     // Legacy: check viewstor: scheme query params
     if (uri.scheme === SCHEME) {
@@ -45,6 +49,10 @@ export class QueryEditorProvider {
       return params.get('connectionId') || undefined;
     }
     return undefined;
+  }
+
+  getDatabaseNameFromUri(uri: vscode.Uri): string | undefined {
+    return connectionMap.get(uri.toString())?.databaseName;
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,9 +15,11 @@ import { SqlDiagnosticProvider } from './editors/sqlDiagnosticProvider';
 import { registerMcpCommands } from './mcp/server';
 import { registerCommands } from './commands';
 import { registerChatParticipant } from './chat/participant';
+import { TempFileManager } from './services/tempFileManager';
 
 let connectionManager: ConnectionManager;
 let outputChannel: vscode.OutputChannel;
+let tempFileManager: TempFileManager;
 
 export function activate(context: vscode.ExtensionContext) {
   outputChannel = vscode.window.createOutputChannel('Viewstor');
@@ -30,6 +32,9 @@ export function activate(context: vscode.ExtensionContext) {
     const queryHistoryProvider = new QueryHistoryProvider(context);
     const queryEditorProvider = new QueryEditorProvider(connectionManager);
     const resultPanelManager = new ResultPanelManager(context);
+    tempFileManager = new TempFileManager(context);
+    tempFileManager.setPostMessage((key, msg) => resultPanelManager.postMessage(key, msg));
+    resultPanelManager.setTempFileManager(tempFileManager);
     const connectionFormPanel = new ConnectionFormPanel(context, connectionManager);
     const folderFormPanel = new FolderFormPanel(context, connectionManager);
 
@@ -52,10 +57,14 @@ export function activate(context: vscode.ExtensionContext) {
       connectionFormPanel,
       folderFormPanel,
       outputChannel,
+      tempFileManager,
     });
 
     // MCP-compatible commands for AI agent integration
     registerMcpCommands(context, connectionManager);
+
+    // Register MCP server for VS Code-internal agents (Copilot, Cursor)
+    registerMcpServerProvider(context);
 
     // Copilot Chat participant (@viewstor)
     registerChatParticipant(context, connectionManager, queryEditorProvider);
@@ -190,6 +199,22 @@ function showMcpSetup() {
   });
 }
 
+function registerMcpServerProvider(context: vscode.ExtensionContext) {
+  // vscode.lm.registerMcpServerDefinitionProvider may not exist in older VS Code versions
+  if (!vscode.lm?.registerMcpServerDefinitionProvider) return;
+
+  const version = vscode.extensions.getExtension('Siyet.viewstor')?.packageJSON.version ?? '0.0.0';
+  const mcpServerPath = path.join(context.extensionPath, 'dist', 'mcp-server.js');
+
+  const provider = vscode.lm.registerMcpServerDefinitionProvider('viewstor.mcpServer', {
+    provideMcpServerDefinitions: async () => [
+      new vscode.McpStdioServerDefinition('Viewstor', 'node', [mcpServerPath], {}, version),
+    ],
+    resolveMcpServerDefinition: async (server: vscode.McpServerDefinition) => server,
+  });
+  context.subscriptions.push(provider);
+}
+
 function showGetStartedOnFirstInstall(context: vscode.ExtensionContext) {
   const shown = context.globalState.get<boolean>('viewstor.getStartedShown');
   if (shown) return;
@@ -312,5 +337,6 @@ function escapeHtml(str: string): string {
 }
 
 export function deactivate() {
+  tempFileManager?.dispose();
   connectionManager?.dispose();
 }

--- a/src/services/tempFileManager.ts
+++ b/src/services/tempFileManager.ts
@@ -1,0 +1,151 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface JsonFileContext {
+  panelKey: string;
+  rowIdx: number;
+  colName: string;
+  colDataType: string;
+}
+
+export interface SqlFileContext {
+  panelKey: string;
+  connectionId: string;
+  tableName?: string;
+  databaseName?: string;
+  context: string; // 'saveEdits' | 'deleteRows' | 'insertRow'
+}
+
+export class TempFileManager {
+  private tmpDir: string;
+  private jsonFiles = new Map<string, JsonFileContext>();
+  private sqlFiles = new Map<string, SqlFileContext>();
+  private disposables: vscode.Disposable[] = [];
+  private postMessage: (panelKey: string, msg: unknown) => void = () => {};
+  private onSqlExecuted: (ctx: SqlFileContext, sql: string) => Promise<void> = async () => {};
+  private onSqlSaved: (ctx: SqlFileContext, sql: string) => Promise<void> = async () => {};
+
+  constructor(context: vscode.ExtensionContext) {
+    this.tmpDir = path.join(context.globalStorageUri.fsPath, 'tmp');
+    fs.mkdirSync(this.tmpDir, { recursive: true });
+
+    this.disposables.push(
+      vscode.workspace.onDidSaveTextDocument(doc => this.handleSave(doc)),
+      vscode.window.onDidChangeActiveTextEditor(e => this.updateContextKey(e)),
+    );
+  }
+
+  setPostMessage(fn: (panelKey: string, msg: unknown) => void) {
+    this.postMessage = fn;
+  }
+
+  setOnSqlExecuted(fn: (ctx: SqlFileContext, sql: string) => Promise<void>) {
+    this.onSqlExecuted = fn;
+  }
+
+  setOnSqlSaved(fn: (ctx: SqlFileContext, sql: string) => Promise<void>) {
+    this.onSqlSaved = fn;
+  }
+
+  async openJsonEditor(jsonStr: string, ctx: JsonFileContext): Promise<void> {
+    const fileName = `viewstor-json-${Date.now()}.json`;
+    const filePath = path.join(this.tmpDir, fileName);
+    let pretty: string;
+    try { pretty = JSON.stringify(JSON.parse(jsonStr), null, 2); } catch { pretty = jsonStr; }
+    fs.writeFileSync(filePath, pretty, 'utf-8');
+
+    const uri = vscode.Uri.file(filePath);
+    this.jsonFiles.set(uri.toString(), ctx);
+    await vscode.window.showTextDocument(uri, { viewColumn: vscode.ViewColumn.Beside, preview: false });
+  }
+
+  async openSqlEditor(sql: string, ctx: SqlFileContext): Promise<void> {
+    const fileName = `viewstor-sql-${Date.now()}.sql`;
+    const filePath = path.join(this.tmpDir, fileName);
+    fs.writeFileSync(filePath, sql, 'utf-8');
+
+    const uri = vscode.Uri.file(filePath);
+    this.sqlFiles.set(uri.toString(), ctx);
+    await vscode.window.showTextDocument(uri, { viewColumn: vscode.ViewColumn.Beside, preview: false });
+    vscode.commands.executeCommand('setContext', 'viewstor.isTempSqlFile', true);
+  }
+
+  async executeSqlFromActiveEditor(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+    const key = editor.document.uri.toString();
+    const ctx = this.sqlFiles.get(key);
+    if (!ctx) return;
+
+    const sql = editor.document.getText();
+    await this.onSqlExecuted(ctx, sql);
+
+    // Close the editor and clean up
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    this.sqlFiles.delete(key);
+    try { fs.unlinkSync(editor.document.uri.fsPath); } catch { /* ok */ }
+    vscode.commands.executeCommand('setContext', 'viewstor.isTempSqlFile', false);
+  }
+
+  isTempSqlFile(uri: vscode.Uri): boolean {
+    return this.sqlFiles.has(uri.toString());
+  }
+
+  private handleSave(doc: vscode.TextDocument) {
+    const key = doc.uri.toString();
+
+    // JSON file saved → apply edit back to cell
+    const jsonCtx = this.jsonFiles.get(key);
+    if (jsonCtx) {
+      const content = doc.getText();
+      let parsed: unknown;
+      try { parsed = JSON.parse(content); } catch {
+        vscode.window.showErrorMessage('Invalid JSON');
+        return;
+      }
+      this.postMessage(jsonCtx.panelKey, {
+        type: 'applyJsonEdit',
+        rowIdx: jsonCtx.rowIdx,
+        colName: jsonCtx.colName,
+        colDataType: jsonCtx.colDataType,
+        newValue: parsed,
+      });
+    }
+
+    // SQL file saved → pin in history
+    const sqlCtx = this.sqlFiles.get(key);
+    if (sqlCtx) {
+      this.onSqlSaved(sqlCtx, doc.getText()).catch(() => {});
+    }
+  }
+
+  private updateContextKey(editor: vscode.TextEditor | undefined) {
+    const isSql = editor ? this.sqlFiles.has(editor.document.uri.toString()) : false;
+    vscode.commands.executeCommand('setContext', 'viewstor.isTempSqlFile', isSql);
+  }
+
+  cleanupForPanel(panelKey: string) {
+    for (const [key, ctx] of this.jsonFiles) {
+      if (ctx.panelKey === panelKey) {
+        this.jsonFiles.delete(key);
+        try { fs.unlinkSync(vscode.Uri.parse(key).fsPath); } catch { /* ok */ }
+      }
+    }
+    for (const [key, ctx] of this.sqlFiles) {
+      if (ctx.panelKey === panelKey) {
+        this.sqlFiles.delete(key);
+        try { fs.unlinkSync(vscode.Uri.parse(key).fsPath); } catch { /* ok */ }
+      }
+    }
+  }
+
+  cleanupAll() {
+    try { fs.rmSync(this.tmpDir, { recursive: true, force: true }); } catch { /* ok */ }
+  }
+
+  dispose() {
+    this.cleanupAll();
+    this.disposables.forEach(d => d.dispose());
+  }
+}

--- a/src/test/e2e/postgres.e2e.test.ts
+++ b/src/test/e2e/postgres.e2e.test.ts
@@ -312,4 +312,136 @@ describeIf(isDockerAvailable)('PostgreSQL Driver E2E', () => {
     const ping = await driver.ping();
     expect(ping).toBe(true);
   });
+
+  // --- Bug regression tests ---
+
+  it('getSchema does not duplicate tables when same name exists in multiple schemas', async () => {
+    // Create a second schema with a table of the same name as in public
+    await driver.execute('CREATE SCHEMA IF NOT EXISTS other_schema');
+    await driver.execute('CREATE TABLE IF NOT EXISTS other_schema.users (id SERIAL PRIMARY KEY, label TEXT)');
+
+    const schema = await driver.getSchema();
+    const pub = schema.find(s => s.name === 'public')!;
+    const other = schema.find(s => s.name === 'other_schema')!;
+
+    // Each schema should have exactly one "users" table, no duplicates
+    const pubUsers = pub.children!.filter(c => c.name === 'users' && c.type === 'table');
+    const otherUsers = other.children!.filter(c => c.name === 'users' && c.type === 'table');
+    expect(pubUsers.length).toBe(1);
+    expect(otherUsers.length).toBe(1);
+
+    // public.users should have 4 columns, other_schema.users should have 2
+    const pubCols = pubUsers[0].children!.filter(c => c.type === 'column');
+    const otherCols = otherUsers[0].children!.filter(c => c.type === 'column');
+    expect(pubCols.length).toBe(4);
+    expect(otherCols.length).toBe(2);
+
+    await driver.execute('DROP TABLE other_schema.users');
+    await driver.execute('DROP SCHEMA other_schema');
+  });
+
+  it('UPDATE with numeric PK executes without error', async () => {
+    const result = await driver.execute(
+      'UPDATE users SET name = \'Alice Updated\' WHERE id = 1'
+    );
+    expect(result.error).toBeUndefined();
+
+    const check = await driver.execute('SELECT name FROM users WHERE id = 1');
+    expect(check.rows[0].name).toBe('Alice Updated');
+
+    // Restore
+    await driver.execute('UPDATE users SET name = \'Alice\' WHERE id = 1');
+  });
+
+  it('UPDATE JSONB column with cast succeeds', async () => {
+    const result = await driver.execute(
+      'UPDATE settings SET metadata = \'{"theme":"blue","fontSize":16}\'::jsonb WHERE id = 1'
+    );
+    expect(result.error).toBeUndefined();
+
+    const check = await driver.execute('SELECT metadata FROM settings WHERE id = 1');
+    expect(check.rows[0].metadata).toMatchObject({ theme: 'blue', fontSize: 16 });
+
+    // Restore
+    await driver.execute(
+      'UPDATE settings SET metadata = \'{"theme":"dark","fontSize":14}\'::jsonb WHERE id = 1'
+    );
+  });
+
+  it('UPDATE JSON column with cast succeeds', async () => {
+    const result = await driver.execute(
+      'UPDATE settings SET config = \'{"newKey":"newVal"}\'::json WHERE id = 1'
+    );
+    expect(result.error).toBeUndefined();
+
+    const check = await driver.execute('SELECT config FROM settings WHERE id = 1');
+    expect(check.rows[0].config).toMatchObject({ newKey: 'newVal' });
+
+    // Restore
+    await driver.execute(
+      'UPDATE settings SET config = \'{"key":"val"}\'::json WHERE id = 1'
+    );
+  });
+
+  it('UPDATE boolean column with TRUE/FALSE succeeds', async () => {
+    const result = await driver.execute(
+      'UPDATE settings SET active = FALSE WHERE id = 1'
+    );
+    expect(result.error).toBeUndefined();
+
+    const check = await driver.execute('SELECT active FROM settings WHERE id = 1');
+    expect(check.rows[0].active).toBe(false);
+
+    // Restore
+    await driver.execute('UPDATE settings SET active = TRUE WHERE id = 1');
+  });
+
+  it('DELETE with numeric PK executes and removes row', async () => {
+    await driver.execute('INSERT INTO users (name, email) VALUES (\'ToDelete\', \'del@test.com\')');
+    const inserted = await driver.execute('SELECT id FROM users WHERE name = \'ToDelete\'');
+    const deleteId = inserted.rows[0].id;
+
+    const result = await driver.execute(`DELETE FROM users WHERE id = ${deleteId}`);
+    expect(result.error).toBeUndefined();
+
+    const check = await driver.execute(`SELECT COUNT(*) as cnt FROM users WHERE id = ${deleteId}`);
+    expect(Number(check.rows[0].cnt)).toBe(0);
+  });
+
+  it('INSERT with DEFAULT values succeeds for table with defaults', async () => {
+    const result = await driver.execute(
+      'INSERT INTO settings ("id", "active", "optional_flag", "metadata", "config") VALUES (DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT) RETURNING *'
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.rows.length).toBe(1);
+    expect(result.rows[0].active).toBe(true); // DEFAULT is true
+
+    // Cleanup
+    await driver.execute(`DELETE FROM settings WHERE id = ${result.rows[0].id}`);
+  });
+
+  it('multi-database: getTableData on second database returns correct data', async () => {
+    // Create a second database and seed data
+    await driver.execute('CREATE DATABASE testdb2');
+
+    const driver2 = new PostgresDriver();
+    const config2 = { ...config, database: 'testdb2' };
+    await driver2.connect(config2);
+    await driver2.execute('CREATE TABLE items (id SERIAL PRIMARY KEY, name TEXT)');
+    await driver2.execute('INSERT INTO items (name) VALUES (\'ItemA\'), (\'ItemB\')');
+
+    const result = await driver2.getTableData('items', 'public');
+    expect(result.error).toBeUndefined();
+    expect(result.rowCount).toBe(2);
+    expect(result.rows[0].name).toBe('ItemA');
+
+    // items should NOT exist in testdb
+    const mainResult = await driver.execute('SELECT * FROM items');
+    expect(mainResult.error).toBeDefined();
+    expect(mainResult.error).toContain('items');
+
+    await driver2.disconnect();
+    // Cleanup: need to disconnect all before dropping DB
+    await driver.execute('DROP DATABASE testdb2');
+  });
 });

--- a/src/test/queryErrors.test.ts
+++ b/src/test/queryErrors.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { levenshtein, parseTablesFromQuery, enhanceColumnError } from '../utils/queryHelpers';
+import {
+  levenshtein,
+  parseTablesFromQuery,
+  enhanceColumnError,
+  buildUpdateSql,
+  buildDeleteSql,
+  buildInsertDefaultSql,
+  quoteTable,
+  sqlValue,
+} from '../utils/queryHelpers';
 
 describe('levenshtein', () => {
   it('should return 0 for identical strings', () => {
@@ -109,7 +118,7 @@ describe('enhanceColumnError', () => {
 
   it('should suggest closest column for ClickHouse error', async () => {
     const result = await enhanceColumnError(
-      "Unknown column 'usrname'",
+      'Unknown column \'usrname\'',
       'SELECT usrname FROM users',
       mockDriver(['id', 'username', 'email']),
     );
@@ -167,5 +176,203 @@ describe('enhanceColumnError', () => {
       mockDriver(['username']),
     );
     expect(result).toContain('Did you mean: "username"?');
+  });
+});
+
+describe('quoteTable', () => {
+  it('should quote table name without schema', () => {
+    expect(quoteTable('users')).toBe('"users"');
+  });
+
+  it('should quote table name with schema', () => {
+    expect(quoteTable('users', 'public')).toBe('"public"."users"');
+  });
+});
+
+describe('sqlValue', () => {
+  it('should return NULL for null/undefined', () => {
+    expect(sqlValue(null)).toBe('NULL');
+    expect(sqlValue(undefined)).toBe('NULL');
+  });
+
+  it('should quote strings', () => {
+    expect(sqlValue('hello')).toBe('\'hello\'');
+  });
+
+  it('should escape single quotes', () => {
+    expect(sqlValue('it\'s')).toBe('\'it\'\'s\'');
+  });
+
+  it('should convert numbers to strings', () => {
+    expect(sqlValue(42)).toBe('\'42\'');
+  });
+
+  it('should JSON.stringify objects', () => {
+    expect(sqlValue({ key: 'value' })).toBe('\'{"key":"value"}\'');
+  });
+
+  it('should JSON.stringify arrays', () => {
+    expect(sqlValue([1, 2, 3])).toBe('\'[1,2,3]\'');
+  });
+
+  it('should escape quotes in JSON', () => {
+    expect(sqlValue({ name: 'O\'Brien' })).toBe('\'{"name":"O\'\'Brien"}\'');
+  });
+
+  it('should output numbers without quotes for numeric types', () => {
+    expect(sqlValue(42, 'integer')).toBe('42');
+    expect(sqlValue(244, 'bigint')).toBe('244');
+    expect(sqlValue(3.14, 'numeric')).toBe('3.14');
+    expect(sqlValue('100', 'int4')).toBe('100');
+  });
+
+  it('should output booleans as TRUE/FALSE', () => {
+    expect(sqlValue(true, 'boolean')).toBe('TRUE');
+    expect(sqlValue(false, 'bool')).toBe('FALSE');
+    expect(sqlValue('true', 'boolean')).toBe('TRUE');
+  });
+
+  it('should still quote numbers without type info', () => {
+    expect(sqlValue(42)).toBe('\'42\'');
+  });
+
+  it('should quote non-numeric string even with numeric type', () => {
+    expect(sqlValue('not-a-number', 'integer')).toBe('\'not-a-number\'');
+  });
+
+  it('should handle empty string', () => {
+    expect(sqlValue('')).toBe('\'\'');
+  });
+
+  it('should handle zero', () => {
+    expect(sqlValue(0, 'integer')).toBe('0');
+  });
+
+  it('should handle negative numbers', () => {
+    expect(sqlValue(-42, 'integer')).toBe('-42');
+    expect(sqlValue(-3.14, 'numeric')).toBe('-3.14');
+  });
+
+  it('should handle float types', () => {
+    expect(sqlValue(1.5, 'float8')).toBe('1.5');
+    expect(sqlValue(2.0, 'double precision')).toBe('2');
+    expect(sqlValue(0.001, 'real')).toBe('0.001');
+  });
+});
+
+describe('buildUpdateSql', () => {
+  it('should build UPDATE with single column change', () => {
+    const sql = buildUpdateSql('users', 'public', ['id'], {
+      changes: { name: 'Alice' },
+      pkValues: { id: 1 },
+      pkTypes: { id: 'bigint' },
+    });
+    expect(sql).toBe('UPDATE "public"."users" SET "name" = \'Alice\' WHERE "id" = 1');
+  });
+
+  it('should build UPDATE with multiple changes and composite PK', () => {
+    const sql = buildUpdateSql('order_items', undefined, ['order_id', 'item_id'], {
+      changes: { quantity: 5, price: null },
+      pkValues: { order_id: 10, item_id: 20 },
+    });
+    expect(sql).toContain('SET "quantity" = \'5\', "price" = NULL');
+    expect(sql).toContain('WHERE "order_id" = \'10\' AND "item_id" = \'20\'');
+  });
+
+  it('should escape quotes in values', () => {
+    const sql = buildUpdateSql('users', undefined, ['id'], {
+      changes: { name: 'O\'Brien' },
+      pkValues: { id: 1 },
+    });
+    expect(sql).toContain('\'O\'\'Brien\'');
+  });
+
+  it('should add ::jsonb cast for json/jsonb columns', () => {
+    const sql = buildUpdateSql('users', 'public', ['id'], {
+      changes: { data: { key: 'value' } },
+      columnTypes: { data: 'jsonb' },
+      pkValues: { id: 1 },
+    });
+    expect(sql).toContain('"data" = \'{"key":"value"}\'::jsonb');
+  });
+
+  it('should add ::jsonb cast for json type', () => {
+    const sql = buildUpdateSql('t', undefined, ['id'], {
+      changes: { config: { a: 1 } },
+      columnTypes: { config: 'json' },
+      pkValues: { id: 1 },
+    });
+    expect(sql).toContain('\'{"a":1}\'::json');
+  });
+
+  it('should not cast non-json columns', () => {
+    const sql = buildUpdateSql('t', undefined, ['id'], {
+      changes: { name: 'test' },
+      columnTypes: { name: 'text' },
+      pkValues: { id: 1 },
+    });
+    expect(sql).not.toContain('::');
+  });
+
+  it('should use numeric PK without quotes when pkTypes provided', () => {
+    const sql = buildUpdateSql('credentials', 'public', ['id'], {
+      changes: { data: { key: 'val' } },
+      columnTypes: { data: 'jsonb' },
+      pkValues: { id: 244 },
+      pkTypes: { id: 'bigint' },
+    });
+    expect(sql).toContain('WHERE "id" = 244');
+    expect(sql).toContain('::jsonb');
+    expect(sql).not.toContain('\'244\'');
+  });
+
+  it('should handle mixed column types in SET clause', () => {
+    const sql = buildUpdateSql('t', undefined, ['id'], {
+      changes: { count: 10, name: 'Alice', active: true, meta: { a: 1 } },
+      columnTypes: { count: 'integer', name: 'varchar', active: 'boolean', meta: 'jsonb' },
+      pkValues: { id: 1 },
+      pkTypes: { id: 'integer' },
+    });
+    expect(sql).toContain('"count" = 10');
+    expect(sql).toContain('"name" = \'Alice\'');
+    expect(sql).toContain('"active" = TRUE');
+    expect(sql).toContain('"meta" = \'{"a":1}\'::jsonb');
+    expect(sql).toContain('WHERE "id" = 1');
+  });
+});
+
+describe('buildDeleteSql', () => {
+  it('should build DELETE with single PK', () => {
+    const sql = buildDeleteSql('users', 'public', ['id'], { id: 42 }, { id: 'bigint' });
+    expect(sql).toBe('DELETE FROM "public"."users" WHERE "id" = 42');
+  });
+
+  it('should quote string PKs', () => {
+    const sql = buildDeleteSql('t', undefined, ['code'], { code: 'ABC' }, { code: 'varchar' });
+    expect(sql).toBe('DELETE FROM "t" WHERE "code" = \'ABC\'');
+  });
+
+  it('should build DELETE with composite PK', () => {
+    const sql = buildDeleteSql('order_items', undefined, ['order_id', 'item_id'], {
+      order_id: 10, item_id: 20,
+    });
+    expect(sql).toBe('DELETE FROM "order_items" WHERE "order_id" = \'10\' AND "item_id" = \'20\'');
+  });
+
+  it('should handle NULL pk values', () => {
+    const sql = buildDeleteSql('t', undefined, ['id'], { id: null });
+    expect(sql).toContain('WHERE "id" = NULL');
+  });
+});
+
+describe('buildInsertDefaultSql', () => {
+  it('should build INSERT with DEFAULT values', () => {
+    const sql = buildInsertDefaultSql('users', 'public', ['id', 'name', 'email']);
+    expect(sql).toBe('INSERT INTO "public"."users" ("id", "name", "email") VALUES (DEFAULT, DEFAULT, DEFAULT) RETURNING *');
+  });
+
+  it('should work without schema', () => {
+    const sql = buildInsertDefaultSql('logs', undefined, ['id', 'message']);
+    expect(sql).toBe('INSERT INTO "logs" ("id", "message") VALUES (DEFAULT, DEFAULT) RETURNING *');
   });
 });

--- a/src/utils/queryHelpers.ts
+++ b/src/utils/queryHelpers.ts
@@ -27,6 +27,84 @@ export function parseTablesFromQuery(sql: string): Array<{ table: string; schema
   return tables;
 }
 
+/** Quote a table name with optional schema */
+export function quoteTable(tableName: string, schema?: string): string {
+  return schema ? `"${schema}"."${tableName}"` : `"${tableName}"`;
+}
+
+/** Escape a value for SQL: NULL → NULL, otherwise single-quoted with escaped quotes */
+const NUMERIC_TYPES = new Set([
+  'integer', 'int', 'int2', 'int4', 'int8', 'bigint', 'smallint',
+  'serial', 'bigserial', 'smallserial',
+  'numeric', 'decimal', 'real', 'float', 'float4', 'float8', 'double precision',
+  'money', 'oid',
+]);
+
+const JSON_TYPES = new Set(['json', 'jsonb']);
+
+/** Escape a value for SQL, respecting column type */
+export function sqlValue(val: unknown, dataType?: string): string {
+  if (val === null || val === undefined) return 'NULL';
+  if (typeof val === 'object') {
+    const str = JSON.stringify(val);
+    return `'${str.replace(/'/g, '\'\'')}'`;
+  }
+  // Numeric types: no quotes if the value is actually a number
+  if (dataType && NUMERIC_TYPES.has(dataType.toLowerCase())) {
+    const num = Number(val);
+    if (!isNaN(num)) return String(num);
+  }
+  // Boolean
+  if (dataType && (dataType === 'boolean' || dataType === 'bool')) {
+    return val === true || val === 'true' ? 'TRUE' : 'FALSE';
+  }
+  const str = String(val);
+  return `'${str.replace(/'/g, '\'\'')}'`;
+}
+
+/** Build UPDATE statement from edit object */
+export function buildUpdateSql(
+  tableName: string,
+  schema: string | undefined,
+  pkColumns: string[],
+  edit: { changes: Record<string, unknown>; columnTypes?: Record<string, string>; pkValues: Record<string, unknown>; pkTypes?: Record<string, string> },
+): string {
+  const setClauses = Object.entries(edit.changes)
+    .map(([col, val]) => {
+      const colType = edit.columnTypes?.[col];
+      const cast = colType && JSON_TYPES.has(colType) ? `::${colType}` : '';
+      return `"${col}" = ${sqlValue(val, colType)}${cast}`;
+    })
+    .join(', ');
+  const whereClauses = pkColumns
+    .map(pk => `"${pk}" = ${sqlValue(edit.pkValues[pk], edit.pkTypes?.[pk])}`)
+    .join(' AND ');
+  return `UPDATE ${quoteTable(tableName, schema)} SET ${setClauses} WHERE ${whereClauses}`;
+}
+
+/** Build DELETE statement from PK values */
+export function buildDeleteSql(
+  tableName: string,
+  schema: string | undefined,
+  pkColumns: string[],
+  pkValues: Record<string, unknown>,
+  pkTypes?: Record<string, string>,
+): string {
+  const whereClauses = pkColumns
+    .map(pk => `"${pk}" = ${sqlValue(pkValues[pk], pkTypes?.[pk])}`)
+    .join(' AND ');
+  return `DELETE FROM ${quoteTable(tableName, schema)} WHERE ${whereClauses}`;
+}
+
+/** Build INSERT with DEFAULT values */
+export function buildInsertDefaultSql(
+  tableName: string,
+  schema: string | undefined,
+  columnNames: string[],
+): string {
+  return `INSERT INTO ${quoteTable(tableName, schema)} (${columnNames.map(c => `"${c}"`).join(', ')}) VALUES (${columnNames.map(() => 'DEFAULT').join(', ')}) RETURNING *`;
+}
+
 /** Enhance "column X does not exist" errors with "Did you mean: Y?" */
 export async function enhanceColumnError(
   error: string,

--- a/src/views/resultPanel.ts
+++ b/src/views/resultPanel.ts
@@ -26,8 +26,11 @@ const DEFAULT_PAGE_SIZE = 100;
 export class ResultPanelManager {
   private panels = new Map<string, vscode.WebviewPanel>();
   private messageDisposables = new Map<string, vscode.Disposable>();
+  private _tempFileManager: any = null;
 
   constructor(private readonly context: vscode.ExtensionContext) {}
+
+  setTempFileManager(t: any) { this._tempFileManager = t; }
 
   show(result: QueryResult, title?: string, opts?: ShowOptions) {
     const panelTitle = title || 'Query Results';
@@ -54,6 +57,7 @@ export class ResultPanelManager {
         this.panels.delete(panelKey);
         this.messageDisposables.get(panelKey)?.dispose();
         this.messageDisposables.delete(panelKey);
+        if (this._tempFileManager) this._tempFileManager.cleanupForPanel(panelKey);
       });
       this.panels.set(panelKey, panel);
       // Move results panel below the editor, then return focus to editor
@@ -67,6 +71,7 @@ export class ResultPanelManager {
     this.messageDisposables.get(panelKey)?.dispose();
 
     const ctx = opts || {};
+    const tfm = this._tempFileManager;
     const disposable = panel.webview.onDidReceiveMessage((msg) => {
       switch (msg.type) {
         case 'changePage':
@@ -108,8 +113,15 @@ export class ResultPanelManager {
           vscode.commands.executeCommand('viewstor._saveEdits',
             ctx.connectionId, ctx.tableName, ctx.schema, ctx.pkColumns, msg.edits, ctx.databaseName);
           break;
-        case 'openJsonInTab':
-          vscode.commands.executeCommand('viewstor._openJsonInTab', msg.json);
+        case 'editJsonInTab':
+          if (tfm) {
+            tfm.openJsonEditor(msg.json, {
+              panelKey,
+              rowIdx: msg.rowIdx,
+              colName: msg.colName,
+              colDataType: msg.colDataType,
+            });
+          }
           break;
         case 'exportAllData':
           if (isTableMode) {
@@ -119,6 +131,21 @@ export class ResultPanelManager {
             vscode.commands.executeCommand('viewstor.exportResults',
               { columns: msg.columns, rows: msg.rows, format: msg.format });
           }
+          break;
+        case 'insertRow':
+          if (isTableMode) {
+            vscode.commands.executeCommand('viewstor._insertRow',
+              ctx.connectionId, ctx.tableName, ctx.schema, msg.row, ctx.databaseName);
+          }
+          break;
+        case 'deleteRows':
+          if (isTableMode) {
+            vscode.commands.executeCommand('viewstor._deleteRows',
+              ctx.connectionId, ctx.tableName, ctx.schema, ctx.pkColumns, msg.rows, ctx.databaseName, msg.pkTypes);
+          }
+          break;
+        case 'rerunLastQuery':
+          vscode.commands.executeCommand('viewstor.runQuery');
           break;
       }
     });
@@ -167,9 +194,11 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
   .btn-primary { background:var(--vscode-button-background) !important; color:var(--vscode-button-foreground) !important; }
   .btn-primary:hover { background:var(--vscode-button-hoverBackground) !important; }
   .container { overflow:auto; flex:1; position:relative; }
-  table { border-collapse:collapse; }
+  table { border-collapse:collapse; table-layout:auto; }
   th, td { padding:4px 8px; border:1px solid var(--vscode-panel-border); text-align:left; white-space:nowrap; max-width:400px; overflow:hidden; text-overflow:ellipsis; user-select:none; }
-  th { position:sticky; top:0; background:var(--vscode-editor-background); font-weight:600; z-index:1; cursor:pointer; }
+  th { position:sticky; top:0; background:var(--vscode-editor-background); font-weight:600; z-index:1; cursor:pointer; position:relative; }
+  th .col-resize-handle { position:absolute; top:0; right:-2px; width:5px; height:100%; cursor:col-resize; z-index:4; }
+  th .col-resize-handle:hover { background:var(--vscode-focusBorder); }
   .row-num, .row-num-header { position:sticky; left:0; z-index:2; background:var(--vscode-editor-background); color:var(--vscode-descriptionForeground); text-align:right; padding:4px 8px; border-right:2px solid var(--vscode-panel-border); min-width:40px; max-width:none; font-size:11px; cursor:default; user-select:none; }
   .row-num-header { z-index:3; top:0; font-weight:600; cursor:default; }
   th:hover { background:var(--vscode-list-hoverBackground); }
@@ -228,14 +257,17 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
     <span id="searchCount" class="search-count"></span>
     <span style="flex:1"></span>
     <button id="exportBtn">Export</button>
+    <button id="addRowBtn" class="hidden">+ Row</button>
+    <button id="deleteRowBtn" class="hidden" disabled>− Row</button>
     <button id="saveBtn" class="btn-primary hidden">Save Changes</button>
+    <button id="refreshBtn" title="Refresh">↻</button>
     <button id="discardBtn" class="hidden">Discard</button>
-    <label>Rows/page: <select id="pageSize">
-      ${PAGE_SIZE_OPTIONS.map(n => `<option value="${n}"${n === activePageSize ? ' selected' : ''}>${n}</option>`).join('')}
-    </select></label>
     <button id="prevPage" disabled>&lt;</button>
     <span id="pageInfo"></span>
     <button id="nextPage">&gt;</button>
+    <label>Rows per page: <select id="pageSize">
+      ${PAGE_SIZE_OPTIONS.map(n => `<option value="${n}"${n === activePageSize ? ' selected' : ''}>${n}</option>`).join('')}
+    </select></label>
   </div>
   ${isTableMode ? `<div class="query-bar">
     <input type="text" id="queryInput" value="${esc(defaultQuery)}" />
@@ -257,24 +289,17 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
     <span id="footerRowCount"></span>
     <button id="refreshCount" title="Get exact row count" style="font-size:11px;padding:1px 5px;">⟳</button>
     <span style="flex:1"></span>
+    <button id="footerRefreshBtn" title="Refresh">↻</button>
+    <button id="footerExportBtn">Export</button>
+    <button id="footerAddRowBtn" class="hidden">+ Row</button>
+    <button id="footerDeleteRowBtn" class="hidden" disabled>− Row</button>
+    <button id="footerSaveBtn" class="btn-primary hidden">Save Changes</button>
+    <button id="footerDiscardBtn" class="hidden">Discard</button>
     <button id="footerPrev" disabled>&lt;</button>
     <span id="footerPageInfo"></span>
     <button id="footerNext">&gt;</button>
   </div>
   <div id="overlay" class="overlay hidden"></div>
-  <div id="jsonPopup" class="popup hidden">
-    <div class="popup-header">
-      <span>JSON Viewer</span>
-      <div style="display:flex;gap:6px;">
-        <button id="jsonOpenTab" class="btn-primary">Open in Tab</button>
-        <button id="jsonClose">Close</button>
-      </div>
-    </div>
-    <div class="popup-body">
-      <textarea id="jsonEditor" class="json-editor"></textarea>
-      <div id="jsonPreview" class="code-preview" style="margin-top:8px;border:1px solid var(--vscode-panel-border);border-radius:2px;max-height:40vh;overflow:auto;"></div>
-    </div>
-  </div>
   <div id="exportPopup" class="popup hidden" style="width:360px;">
     <div class="popup-header">
       <span>Export Data</span>
@@ -296,13 +321,13 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
 <script>
 (function() {
   const vscode = acquireVsCodeApi();
-  const columns = ${safeJsonForScript(result.columns)};
-  const pageRows = ${safeJsonForScript(result.rows)};
+  let columns = ${safeJsonForScript(result.columns)};
+  let pageRows = ${safeJsonForScript(result.rows)};
   const pkColumns = ${safeJsonForScript(opts?.pkColumns || [])};
   const IS_READONLY = ${!!opts?.readonly};
   const IS_TABLE_MODE = ${isTableMode};
-  const TOTAL_ROW_COUNT = ${totalRowCount};
-  const IS_ESTIMATED_COUNT = ${isEstimatedCount};
+  let TOTAL_ROW_COUNT = ${totalRowCount};
+  let IS_ESTIMATED_COUNT = ${isEstimatedCount};
   let currentPage = ${currentPage};
   let pageSize = ${activePageSize};
   let totalPages = Math.max(1, Math.ceil(TOTAL_ROW_COUNT / pageSize));
@@ -324,7 +349,7 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
   }
 
   let pendingEdits = new Map();
-  const originalRows = JSON.parse(JSON.stringify(pageRows));
+  let originalRows = JSON.parse(JSON.stringify(pageRows));
 
   const jsonTypes = new Set(['json','jsonb','Object']);
   const boolTypes = new Set(['boolean','Bool']);
@@ -373,10 +398,10 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
         if (sortColumns.length > 1) icon += '<sup>' + (sortIdx+1) + '</sup>';
         icon += '</span>';
       }
-      return '<th data-col="' + i + '">' + escHtml(c.name) + icon + '<br><small>' + escHtml(c.dataType) + '</small></th>';
+      return '<th data-col="' + i + '">' + escHtml(c.name) + icon + '<br><small>' + escHtml(c.dataType) + '</small><div class="col-resize-handle"></div></th>';
     }).join('');
     headerRow.querySelectorAll('th[data-col]').forEach(th => {
-      th.addEventListener('click', (e) => handleSortClick(Number(th.dataset.col), e.shiftKey));
+      th.addEventListener('click', (e) => { if (e.target.classList && e.target.classList.contains('col-resize-handle')) return; handleSortClick(Number(th.dataset.col), e.shiftKey); });
       th.addEventListener('contextmenu', (e) => {
         e.preventDefault();
         closeContextMenu();
@@ -397,6 +422,34 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
         ctxMenuEl.appendChild(selectBtn);
         document.body.appendChild(ctxMenuEl);
       });
+      // Column resize handle
+      var handle = th.querySelector('.col-resize-handle');
+      if (handle) {
+        handle.addEventListener('mousedown', function(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          var startX = e.clientX;
+          var startWidth = th.offsetWidth;
+          var colIdx = Number(th.dataset.col);
+          function onMove(ev) {
+            var newWidth = Math.max(40, startWidth + ev.clientX - startX);
+            th.style.width = newWidth + 'px';
+            th.style.minWidth = newWidth + 'px';
+            th.style.maxWidth = newWidth + 'px';
+            // Apply to all td in same column
+            document.querySelectorAll('#dataBody tr').forEach(function(row) {
+              var td = row.children[colIdx + 1]; // +1 for row-num column
+              if (td) { td.style.width = newWidth + 'px'; td.style.minWidth = newWidth + 'px'; td.style.maxWidth = newWidth + 'px'; }
+            });
+          }
+          function onUp() {
+            document.removeEventListener('mousemove', onMove);
+            document.removeEventListener('mouseup', onUp);
+          }
+          document.addEventListener('mousemove', onMove);
+          document.addEventListener('mouseup', onUp);
+        });
+      }
     });
   }
 
@@ -440,7 +493,7 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
         const val = pageRows[ri][col.name];
         if (val !== null && val !== undefined && (jsonTypes.has(col.dataType) || isComplexValue(val))) {
           const str = typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val);
-          showJsonPopup(str, ri, col);
+          openJsonInTab(str, ri, col);
           return;
         }
         if (!IS_READONLY) startEdit(td, ci, ri);
@@ -579,6 +632,12 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
         brTd.appendChild(handle);
       }
     }
+    // Toggle delete row buttons
+    var noSel = selectedCells.size === 0;
+    var delBtn = document.getElementById('deleteRowBtn');
+    if (delBtn) delBtn.disabled = noSel;
+    var fDelBtn = document.getElementById('footerDeleteRowBtn');
+    if (fDelBtn) fDelBtn.disabled = noSel;
   }
 
   // --- Context menu ---
@@ -604,6 +663,20 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
       btn.addEventListener('click', () => { copySelection(f.fmt); closeContextMenu(); });
       ctxMenuEl.appendChild(btn);
     });
+    // Delete row option (only in table mode, not readonly, with PKs)
+    if (!IS_READONLY && IS_TABLE_MODE && pkColumns.length > 0) {
+      var sep = document.createElement('div');
+      sep.style.cssText = 'height:1px;background:var(--vscode-menu-separatorBackground, var(--vscode-panel-border));margin:4px 0;';
+      ctxMenuEl.appendChild(sep);
+      var delBtn = document.createElement('button');
+      delBtn.textContent = 'Delete Row(s)';
+      delBtn.style.color = 'var(--vscode-errorForeground)';
+      delBtn.addEventListener('click', function() {
+        closeContextMenu();
+        sendDeleteRows();
+      });
+      ctxMenuEl.appendChild(delBtn);
+    }
     document.body.appendChild(ctxMenuEl);
   }
   function closeContextMenu() { if (ctxMenuEl) { ctxMenuEl.remove(); ctxMenuEl = null; } }
@@ -738,9 +811,15 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
     const oldStr = typeof oldVal === 'object' && oldVal !== null ? JSON.stringify(oldVal) : String(oldVal);
     if (newStr !== oldStr) {
       const pkValues = {};
-      pkColumns.forEach(pk => { pkValues[pk] = originalRows[rowIdx][pk]; });
-      if (!pendingEdits.has(rowIdx.toString())) pendingEdits.set(rowIdx.toString(), { rowIdx, changes: {}, pkValues });
+      const pkTypes = {};
+      pkColumns.forEach(pk => {
+        pkValues[pk] = originalRows[rowIdx][pk];
+        var pkCol = columns.find(function(c) { return c.name === pk; });
+        if (pkCol) pkTypes[pk] = pkCol.dataType;
+      });
+      if (!pendingEdits.has(rowIdx.toString())) pendingEdits.set(rowIdx.toString(), { rowIdx, changes: {}, columnTypes: {}, pkValues, pkTypes });
       pendingEdits.get(rowIdx.toString()).changes[col.name] = newVal;
+      pendingEdits.get(rowIdx.toString()).columnTypes[col.name] = col.dataType;
       td.classList.add('modified');
     } else {
       const edit = pendingEdits.get(rowIdx.toString());
@@ -764,7 +843,7 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
       const col = columns[colIdx];
       const val = pageRows[rowIdx][col.name];
       if (val !== null && val !== undefined && (jsonTypes.has(col.dataType) || isComplexValue(val))) {
-        showJsonPopup(typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val), rowIdx, col);
+        openJsonInTab(typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val), rowIdx, col);
         return;
       }
       if (!IS_READONLY) startEdit(td, colIdx, rowIdx);
@@ -775,6 +854,8 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
     const hasEdits = pendingEdits.size > 0;
     document.getElementById('saveBtn').classList.toggle('hidden', !hasEdits);
     document.getElementById('discardBtn').classList.toggle('hidden', !hasEdits);
+    document.getElementById('footerSaveBtn').classList.toggle('hidden', !hasEdits);
+    document.getElementById('footerDiscardBtn').classList.toggle('hidden', !hasEdits);
   }
 
   document.getElementById('saveBtn').addEventListener('click', () => {
@@ -792,41 +873,44 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
     updateSaveButtons();
   });
 
-  // --- JSON Popup (editable) ---
-  let jsonEditContext = null;
-  function updateJsonPreview() {
-    const editor = document.getElementById('jsonEditor');
-    const preview = document.getElementById('jsonPreview');
-    if (preview) preview.innerHTML = highlightJson(editor.value);
+  // --- Add / Delete Rows ---
+  if (!IS_READONLY && IS_TABLE_MODE && pkColumns.length > 0) {
+    document.getElementById('addRowBtn').classList.remove('hidden');
+    document.getElementById('deleteRowBtn').classList.remove('hidden');
+    document.getElementById('footerAddRowBtn').classList.remove('hidden');
+    document.getElementById('footerDeleteRowBtn').classList.remove('hidden');
   }
-  function showJsonPopup(jsonStr, rowIdx, col) {
-    jsonEditContext = { rowIdx, col };
-    const editor = document.getElementById('jsonEditor');
-    try { editor.value = JSON.stringify(JSON.parse(jsonStr), null, 2); } catch { editor.value = jsonStr; }
-    document.getElementById('jsonPopup').classList.remove('hidden');
-    document.getElementById('overlay').classList.remove('hidden');
-    updateJsonPreview();
-    editor.focus();
-    editor.addEventListener('input', updateJsonPreview);
-  }
-  function closeJsonPopup(save) {
-    if (save && jsonEditContext && !IS_READONLY) {
-      const editor = document.getElementById('jsonEditor');
-      const { rowIdx, col } = jsonEditContext;
-      const td = document.querySelector('td[data-row="' + rowIdx + '"][data-col="' + columns.indexOf(col) + '"]');
-      if (td) finishEdit(td, col, rowIdx, editor.value);
-    }
-    jsonEditContext = null;
-    document.getElementById('jsonPopup').classList.add('hidden');
-    document.getElementById('overlay').classList.add('hidden');
-  }
-  document.getElementById('jsonClose').addEventListener('click', () => closeJsonPopup(false));
-  document.getElementById('jsonOpenTab').addEventListener('click', () => {
-    const editor = document.getElementById('jsonEditor');
-    try { const pretty = JSON.stringify(JSON.parse(editor.value), null, 2); vscode.postMessage({ type: 'openJsonInTab', json: pretty }); }
-    catch { vscode.postMessage({ type: 'openJsonInTab', json: editor.value }); }
-    closeJsonPopup(false);
+
+  document.getElementById('addRowBtn').addEventListener('click', () => {
+    var newRow = {};
+    columns.forEach(function(c) { newRow[c.name] = null; });
+    vscode.postMessage({ type: 'insertRow', row: newRow });
   });
+
+  function sendDeleteRows() {
+    var rowSet = new Set();
+    selectedCells.forEach(function(key) { rowSet.add(parseInt(key.split(':')[0])); });
+    if (rowSet.size === 0) return;
+    var rowsToDelete = [];
+    var pTypes = {};
+    pkColumns.forEach(function(pk) {
+      var c = columns.find(function(col) { return col.name === pk; });
+      if (c) pTypes[pk] = c.dataType;
+    });
+    rowSet.forEach(function(ri) {
+      var pkVals = {};
+      pkColumns.forEach(function(pk) { pkVals[pk] = pageRows[ri][pk]; });
+      rowsToDelete.push(pkVals);
+    });
+    vscode.postMessage({ type: 'deleteRows', rows: rowsToDelete, pkTypes: pTypes });
+  }
+
+  document.getElementById('deleteRowBtn').addEventListener('click', sendDeleteRows);
+
+  // --- JSON: open in native VS Code tab ---
+  function openJsonInTab(jsonStr, rowIdx, col) {
+    vscode.postMessage({ type: 'editJsonInTab', json: jsonStr, rowIdx: rowIdx, colName: col.name, colDataType: col.dataType });
+  }
 
   // --- Export Popup ---
   function showExportPopup() {
@@ -840,6 +924,17 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
     document.getElementById('exportPopup').classList.add('hidden');
     document.getElementById('overlay').classList.add('hidden');
   }
+  document.getElementById('refreshBtn').addEventListener('click', () => {
+    if (IS_TABLE_MODE) {
+      if (queryInput && queryInput.value.trim()) {
+        runCustomQuery();
+      } else {
+        vscode.postMessage({ type: 'changePage', page: currentPage, pageSize: pageSize, orderBy: sortColumns });
+      }
+    } else {
+      vscode.postMessage({ type: 'rerunLastQuery' });
+    }
+  });
   document.getElementById('exportBtn').addEventListener('click', showExportPopup);
   document.getElementById('exportClose').addEventListener('click', closeExportPopup);
   document.getElementById('exportConfirm').addEventListener('click', () => {
@@ -883,6 +978,14 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
       vscode.postMessage({ type: 'changePageSize', pageSize, orderBy: sortColumns });
     }
   });
+
+  // Footer button delegates
+  document.getElementById('footerRefreshBtn').addEventListener('click', () => document.getElementById('refreshBtn').click());
+  document.getElementById('footerExportBtn').addEventListener('click', () => document.getElementById('exportBtn').click());
+  document.getElementById('footerAddRowBtn').addEventListener('click', () => document.getElementById('addRowBtn').click());
+  document.getElementById('footerDeleteRowBtn').addEventListener('click', () => document.getElementById('deleteRowBtn').click());
+  document.getElementById('footerSaveBtn').addEventListener('click', () => document.getElementById('saveBtn').click());
+  document.getElementById('footerDiscardBtn').addEventListener('click', () => document.getElementById('discardBtn').click());
 
   function showLoading() { document.getElementById('loadingOverlay').classList.remove('hidden'); }
   function hideLoading() { document.getElementById('loadingOverlay').classList.add('hidden'); }
@@ -930,6 +1033,36 @@ function buildResultHtml(result: QueryResult, opts?: ShowOptions): string {
       const btn = document.getElementById('refreshCount');
       btn.disabled = false;
       document.getElementById('footerRowCount').textContent = msg.count + ' row' + (msg.count !== 1 ? 's' : '');
+    }
+    if (msg.type === 'rerunQuery') {
+      if (queryInput && queryInput.value.trim()) {
+        runCustomQuery();
+      } else {
+        vscode.postMessage({ type: 'changePage', page: currentPage, pageSize: pageSize, orderBy: sortColumns });
+      }
+    }
+    if (msg.type === 'applyJsonEdit') {
+      var colIdx = columns.findIndex(function(c) { return c.name === msg.colName; });
+      if (colIdx >= 0) {
+        var col = columns[colIdx];
+        var td = document.querySelector('td[data-row="' + msg.rowIdx + '"][data-col="' + colIdx + '"]');
+        if (td) finishEdit(td, col, msg.rowIdx, msg.newValue);
+      }
+    }
+    if (msg.type === 'updateData') {
+      columns = msg.columns;
+      pageRows = msg.rows;
+      TOTAL_ROW_COUNT = msg.rowCount;
+      if (msg.currentPage !== undefined) currentPage = msg.currentPage;
+      if (msg.totalPages !== undefined) totalPages = msg.totalPages;
+      if (msg.isEstimatedCount !== undefined) IS_ESTIMATED_COUNT = msg.isEstimatedCount;
+      pendingEdits.clear();
+      originalRows = JSON.parse(JSON.stringify(pageRows));
+      document.getElementById('statsInfo').textContent = msg.executionTimeMs + 'ms';
+      renderHeader();
+      renderPage();
+      updateSaveButtons();
+      hideLoading();
     }
   });
 


### PR DESCRIPTION
## Summary

- **Native MCP server** via `mcpServerDefinitionProviders` — zero-config discovery by Copilot/Cursor (#43)
- **Resizable columns** — drag header edge (#44)
- **Add/delete rows** — toolbar + context menu, with SQL confirmation (#45)
- **JSON editing** via native VS Code tabs — Ctrl+S applies back to cell
- **SQL confirmation** via native VS Code tabs — ▶ Play button, Ctrl+Enter, Ctrl+S pins to history
- **Type-aware SQL** — numeric PKs without quotes, boolean TRUE/FALSE, ::jsonb/::json casts
- **Refresh button** ↻, inline table icon, footer toolbar
- **Multi-DB SQL editor fix** — queries on secondary DB now use correct connection
- **In-place grid updates** — custom SQL and pagination don't recreate the page
- 96 unit tests + 8 new e2e regression tests

Closes #43, #44, #45

## Test plan
- [ ] Resize columns by dragging header edge
- [ ] Add row (+ Row) → confirm SQL in tab → ▶ execute
- [ ] Delete row (− Row or right-click) → confirm SQL in tab → ▶ execute  
- [ ] Edit JSON cell → double-click → edit in tab → Ctrl+S → value applied
- [ ] Save Changes → SQL opens in tab → ▶ execute → grid refreshes
- [ ] Custom SQL preserved after insert/delete/save
- [ ] Multi-DB: open query from second DB → correct database
- [ ] MCP: extension appears in MCP list without config

🤖 Generated with [Claude Code](https://claude.com/claude-code)