### PR TITLE
feat: data diff — compare tables across connections (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Viewstor are documented here. Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+- **Data diff** — compare data between tables or connections with side-by-side visualization. Row diff matches by PK and highlights added/removed/changed cells; Schema diff compares column types, nullability, and PK status. Export as CSV/JSON. Accessible via right-click "Compare With..." on tables or "Viewstor: Compare Data" command palette ([#5](https://github.com/Siyet/viewstor/issues/5))
+- **Regression prevention** — split monolithic `commands/index.ts` (1598 lines) into 7 focused modules, added 161 tests (ConnectionManager, driver contracts, integration workflows, activation smoke), connectionMap auto-cleanup, getDriverForDatabase concurrency lock, CI changeset size guard ([#59](https://github.com/Siyet/viewstor/issues/59), [#60](https://github.com/Siyet/viewstor/issues/60), [#61](https://github.com/Siyet/viewstor/issues/61))
+
 ## [0.3.2] — 2026-04-13
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,17 @@ Multi-source: `ChartDataSource` in config, resolved via `PinnedQueryProvider` (i
 
 Settings: `viewstor.grafanaUrl`, `viewstor.grafanaApiKey` for direct Grafana push.
 
+### Data Diff
+`src/diff/diffEngine.ts` — pure functions: `computeRowDiff()` matches rows by key columns (PK or user-specified), compares all non-key columns by stringifying values. `computeSchemaDiff()` compares column names, types, nullability, PK status. `exportDiffAsCsv()` / `exportDiffAsJson()` for diff export. No vscode dependency, fully unit-tested.
+
+`src/diff/diffTypes.ts` — `DiffSource`, `DiffOptions`, `RowDiffResult`, `MatchedRow`, `SchemaDiffResult`, `ColumnCompare`.
+
+`src/diff/diffPanel.ts` — `DiffPanelManager`, webview panel for side-by-side diff visualization. Row diff tab (added/removed/changed rows with cell-level highlighting) and Schema diff tab (column comparison). Export as CSV/JSON. Swap sides button.
+
+`src/commands/diffCommands.ts` — `viewstor.compareWith` (context menu on tables), `viewstor.compareData` (command palette). Auto-detects PK columns; prompts user if no PK found. Fetches data from both sources, computes diff, opens panel.
+
+Settings: `viewstor.diffRowLimit` (default 10000, max 100000).
+
 ### SQL Autocomplete
 `src/editors/completionProvider.ts` — CompletionItemProvider triggered on `.`. Caches per connection (60s TTL, tracked timers for cleanup). Context-aware: after FROM/JOIN → tables only, after `table.` → that table's columns, general context → columns from query's referenced tables + tables + keywords. Aliases resolved from `FROM table AS alias`. Enum value suggestions after `=`/`!=`/`<>`/`IN` operators (PG: fetches from `pg_enum`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,21 @@ Usage in Claude Code config:
 `src/utils/queryHelpers.ts` — pure functions for SQL generation and error enhancement: `levenshtein`, `parseTablesFromQuery`, `enhanceColumnError`, `buildUpdateSql`, `buildDeleteSql`, `buildInsertDefaultSql`, `quoteTable`, `sqlValue`. All vscode-independent, fully unit-tested.
 
 ### Commands
-`src/commands/index.ts` — all `viewstor.*` commands. Notable: `_fetchPage` (server-side pagination), `_exportAllData` (fetches up to 100k rows), `_cancelQuery`, `_refreshCount` (exact COUNT), `_insertRow` (INSERT with DEFAULT), `_deleteRows` (DELETE by PK with confirmation), `reportIssue` (GitHub issue with env info). All commands support `databaseName` parameter for multi-DB connections.
+`src/commands/` — split into focused modules to prevent regressions:
+
+| File | Scope |
+|---|---|
+| `index.ts` | Orchestrator: registers CodeLens, document handlers, delegates to modules |
+| `shared.ts` | `CommandContext` interface, shared state (queryResults, historyDocMap), helpers |
+| `queryCommands.ts` | `runQuery`, `executeTempSql`, `cancelQuery`, safe mode, TempFileManager callbacks |
+| `tableCommands.ts` | `showTableData`, `_fetchPage`, `_saveEdits`, `_insertRow`, `_deleteRows`, `_runCustomTableQuery`, MCP table |
+| `connectionCommands.ts` | Connection/folder CRUD, import, schema visibility |
+| `historyCommands.ts` | Query history: open, pin, unpin, rename, clear |
+| `schemaCommands.ts` | `showDDL`, `copyName`, rename/create/drop objects, `reportIssue` |
+| `exportCommands.ts` | Export (CSV/TSV/JSON/Markdown), visualize, Grafana, MCP query |
+| `diffCommands.ts` | `compareWith` (context menu), `compareData` (command palette) |
+
+All commands support `databaseName` parameter for multi-DB connections.
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Viewstor is a free, open-source extension that covers PostgreSQL, Redis, ClickHo
 | **Import from DBeaver/DataGrip/pgAdmin** | Yes | No | No | No |
 | **Index hints** | Yes | No | No | No |
 | **Chart visualization** | 12 chart types, free | No | No | No |
+| **Data diff** | Row + schema diff, free | No | No | No |
 | **Color-coded folders** | Nested, inherited | No | No | No |
 | **Localization** | 12 languages | English only | English only | English only |
 
@@ -135,6 +136,18 @@ Visualize query results as interactive charts — powered by [Apache ECharts](ht
 5. Select which numeric columns to include, set a label — done
 
 Example: pin `SELECT ts, cpu FROM metrics` and `SELECT ts, mem FROM metrics`, open chart from CPU, add Memory as data source with join on `ts` — both metrics on the same time axis.
+
+### Data Diff
+
+Compare data between tables — even across different connections (dev vs staging):
+
+- Right-click a table → **Compare With...** → pick another table from any connected database
+- **Row diff** — matches rows by primary key, highlights added/removed/changed cells side-by-side
+- **Schema diff** — compare column names, types, nullability, and PK status
+- Export diff as CSV or JSON
+- Configure max rows in settings (`viewstor.diffRowLimit`, default 10,000)
+
+Also available via Command Palette: `Viewstor: Compare Data`.
 
 ### Copilot Chat (`@viewstor`)
 

--- a/README.md
+++ b/README.md
@@ -253,11 +253,18 @@ npm run package      # .vsix package
 
 ### Testing
 
-Unit tests use [vitest](https://vitest.dev/). E2E tests use [testcontainers](https://www.npmjs.com/package/testcontainers) to spin up PostgreSQL, Redis, and ClickHouse in Docker. Auto-skipped if Docker is unavailable.
+700+ tests across three layers:
+
+| Layer | Runner | Coverage |
+|---|---|---|
+| Unit tests | [vitest](https://vitest.dev/) | Pure logic: diff engine, chart transforms, query helpers, export/import, ConnectionManager, driver contracts, workflows |
+| VS Code tests | Mocha + `@vscode/test-cli` | Extension activation, command registration, CodeLens, query editor |
+| E2E tests | vitest + [testcontainers](https://www.npmjs.com/package/testcontainers) | Real PG/Redis/CH/SQLite drivers (Docker required, auto-skipped otherwise) |
 
 ### CI/CD
 
-- **CI** (on PR, trunk push, tags): lint → unit tests → build → `npm audit`
+- **CI** (on PR, trunk push, tags): lint → unit tests → e2e tests → build → security audit → changeset size check
+- **Changeset size** — warns when a PR changes 30+ files (historically the threshold for cascading regressions)
 - **Release** (on `v*` tag): build → test → publish to Marketplace → GitHub Release with `.vsix`
 
 ## Contributing

--- a/l10n/nls/package.nls.ar.json
+++ b/l10n/nls/package.nls.ar.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "تصدير إلى لوحة Grafana",
   "config.grafanaUrl.description": "عنوان URL لخادم Grafana لإرسال لوحات المعلومات مباشرة (مثال: https://grafana.example.com).",
   "config.grafanaApiKey.description": "مفتاح API لـ Grafana لإرسال لوحات المعلومات. أنشئ مفتاحاً بصلاحية Editor.",
-  "chat.command.chart": "إنشاء رسم بياني من استعلام"
+  "chat.command.chart": "إنشاء رسم بياني من استعلام",
+  "command.compareWith": "مقارنة مع...",
+  "command.compareData": "مقارنة البيانات",
+  "config.diffRowLimit.description": "الحد الأقصى لعدد الصفوف المقارنة لكل جدول."
 }

--- a/l10n/nls/package.nls.bn.json
+++ b/l10n/nls/package.nls.bn.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "Grafana ড্যাশবোর্ডে রপ্তানি",
   "config.grafanaUrl.description": "সরাসরি ড্যাশবোর্ড পুশ করার জন্য Grafana সার্ভার URL (যেমন, https://grafana.example.com)।",
   "config.grafanaApiKey.description": "ড্যাশবোর্ড পুশ করার জন্য Grafana API কী। Editor ভূমিকা দিয়ে একটি কী তৈরি করুন।",
-  "chat.command.chart": "একটি কোয়েরি থেকে চার্ট ভিজুয়ালাইজেশন তৈরি করুন"
+  "chat.command.chart": "একটি কোয়েরি থেকে চার্ট ভিজুয়ালাইজেশন তৈরি করুন",
+  "command.compareWith": "তুলনা করুন...",
+  "command.compareData": "ডেটা তুলনা",
+  "config.diffRowLimit.description": "প্রতি টেবিলে তুলনা করার সর্বোচ্চ সারি সংখ্যা।"
 }

--- a/l10n/nls/package.nls.de.json
+++ b/l10n/nls/package.nls.de.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "In Grafana-Dashboard exportieren",
   "config.grafanaUrl.description": "Grafana-Server-URL für direkten Dashboard-Push (z. B. https://grafana.example.com).",
   "config.grafanaApiKey.description": "Grafana-API-Schlüssel zum Pushen von Dashboards. Erstellen Sie einen Schlüssel mit der Editor-Rolle.",
-  "chat.command.chart": "Diagramm-Visualisierung aus einer Abfrage erstellen"
+  "chat.command.chart": "Diagramm-Visualisierung aus einer Abfrage erstellen",
+  "command.compareWith": "Vergleichen mit...",
+  "command.compareData": "Daten vergleichen",
+  "config.diffRowLimit.description": "Maximale Zeilenanzahl pro Tabelle beim Vergleich."
 }

--- a/l10n/nls/package.nls.es.json
+++ b/l10n/nls/package.nls.es.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "Exportar a panel de Grafana",
   "config.grafanaUrl.description": "URL del servidor Grafana para enviar paneles directamente (ej., https://grafana.example.com).",
   "config.grafanaApiKey.description": "Clave API de Grafana para enviar paneles. Cree una clave con el rol Editor.",
-  "chat.command.chart": "Generar una visualización de gráfico a partir de una consulta"
+  "chat.command.chart": "Generar una visualización de gráfico a partir de una consulta",
+  "command.compareWith": "Comparar con...",
+  "command.compareData": "Comparar datos",
+  "config.diffRowLimit.description": "Número máximo de filas a comparar por tabla."
 }

--- a/l10n/nls/package.nls.fr.json
+++ b/l10n/nls/package.nls.fr.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "Exporter vers un tableau de bord Grafana",
   "config.grafanaUrl.description": "URL du serveur Grafana pour l'envoi direct de tableaux de bord (ex. : https://grafana.example.com).",
   "config.grafanaApiKey.description": "Clé API Grafana pour envoyer des tableaux de bord. Créez une clé avec le rôle Editor.",
-  "chat.command.chart": "Générer un graphique à partir d'une requête"
+  "chat.command.chart": "Générer un graphique à partir d'une requête",
+  "command.compareWith": "Comparer avec...",
+  "command.compareData": "Comparer les données",
+  "config.diffRowLimit.description": "Nombre maximum de lignes à comparer par table."
 }

--- a/l10n/nls/package.nls.hi.json
+++ b/l10n/nls/package.nls.hi.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "Grafana डैशबोर्ड में निर्यात करें",
   "config.grafanaUrl.description": "डैशबोर्ड भेजने के लिए Grafana सर्वर URL (उदा., https://grafana.example.com)।",
   "config.grafanaApiKey.description": "डैशबोर्ड भेजने के लिए Grafana API कुंजी। Editor भूमिका के साथ एक कुंजी बनाएँ।",
-  "chat.command.chart": "किसी क्वेरी से चार्ट विज़ुअलाइज़ेशन बनाएँ"
+  "chat.command.chart": "किसी क्वेरी से चार्ट विज़ुअलाइज़ेशन बनाएँ",
+  "command.compareWith": "तुलना करें...",
+  "command.compareData": "डेटा तुलना",
+  "config.diffRowLimit.description": "प्रति तालिका तुलना की जाने वाली पंक्तियों की अधिकतम संख्या।"
 }

--- a/l10n/nls/package.nls.ja.json
+++ b/l10n/nls/package.nls.ja.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "Grafanaダッシュボードにエクスポート",
   "config.grafanaUrl.description": "ダッシュボードを直接プッシュするためのGrafanaサーバーURL（例: https://grafana.example.com）。",
   "config.grafanaApiKey.description": "ダッシュボードをプッシュするためのGrafana APIキー。Editorロールでキーを作成してください。",
-  "chat.command.chart": "クエリからチャートを生成"
+  "chat.command.chart": "クエリからチャートを生成",
+  "command.compareWith": "比較...",
+  "command.compareData": "データ比較",
+  "config.diffRowLimit.description": "テーブルごとの最大比較行数。"
 }

--- a/l10n/nls/package.nls.json
+++ b/l10n/nls/package.nls.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "Export to Grafana Dashboard",
   "config.grafanaUrl.description": "Grafana server URL for direct dashboard push (e.g., https://grafana.example.com).",
   "config.grafanaApiKey.description": "Grafana API key for pushing dashboards. Create a key with Editor role.",
-  "chat.command.chart": "Generate a chart visualization from a query"
+  "chat.command.chart": "Generate a chart visualization from a query",
+  "command.compareWith": "Compare With...",
+  "command.compareData": "Compare Data",
+  "config.diffRowLimit.description": "Maximum number of rows to compare per table. Larger values use more memory."
 }

--- a/l10n/nls/package.nls.ko.json
+++ b/l10n/nls/package.nls.ko.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "Grafana 대시보드로 내보내기",
   "config.grafanaUrl.description": "대시보드를 직접 푸시하기 위한 Grafana 서버 URL (예: https://grafana.example.com).",
   "config.grafanaApiKey.description": "대시보드 푸시를 위한 Grafana API 키. Editor 역할로 키를 생성하세요.",
-  "chat.command.chart": "쿼리에서 차트 시각화 생성"
+  "chat.command.chart": "쿼리에서 차트 시각화 생성",
+  "command.compareWith": "비교...",
+  "command.compareData": "데이터 비교",
+  "config.diffRowLimit.description": "테이블당 비교할 최대 행 수."
 }

--- a/l10n/nls/package.nls.pt-br.json
+++ b/l10n/nls/package.nls.pt-br.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "Exportar para painel do Grafana",
   "config.grafanaUrl.description": "URL do servidor Grafana para envio direto de painéis (ex.: https://grafana.example.com).",
   "config.grafanaApiKey.description": "Chave de API do Grafana para enviar painéis. Crie uma chave com a função Editor.",
-  "chat.command.chart": "Gerar uma visualização de gráfico a partir de uma consulta"
+  "chat.command.chart": "Gerar uma visualização de gráfico a partir de uma consulta",
+  "command.compareWith": "Comparar com...",
+  "command.compareData": "Comparar dados",
+  "config.diffRowLimit.description": "Número máximo de linhas a comparar por tabela."
 }

--- a/l10n/nls/package.nls.ru.json
+++ b/l10n/nls/package.nls.ru.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "Экспорт в дашборд Grafana",
   "config.grafanaUrl.description": "URL сервера Grafana для прямой отправки дашбордов (например, https://grafana.example.com).",
   "config.grafanaApiKey.description": "API-ключ Grafana для отправки дашбордов. Создайте ключ с ролью Editor.",
-  "chat.command.chart": "Сгенерировать визуализацию графика из запроса"
+  "chat.command.chart": "Сгенерировать визуализацию графика из запроса",
+  "command.compareWith": "Сравнить с...",
+  "command.compareData": "Сравнить данные",
+  "config.diffRowLimit.description": "Максимальное количество строк для сравнения на таблицу."
 }

--- a/l10n/nls/package.nls.zh-cn.json
+++ b/l10n/nls/package.nls.zh-cn.json
@@ -48,5 +48,8 @@
   "command.exportGrafana": "导出到 Grafana 仪表板",
   "config.grafanaUrl.description": "用于直接推送仪表板的 Grafana 服务器 URL（例如 https://grafana.example.com）。",
   "config.grafanaApiKey.description": "用于推送仪表板的 Grafana API 密钥。请创建具有 Editor 角色的密钥。",
-  "chat.command.chart": "从查询生成图表可视化"
+  "chat.command.chart": "从查询生成图表可视化",
+  "command.compareWith": "比较...",
+  "command.compareData": "比较数据",
+  "config.diffRowLimit.description": "每个表比较的最大行数。"
 }

--- a/package.json
+++ b/package.json
@@ -322,6 +322,18 @@
         "command": "viewstor.exportGrafana",
         "title": "%command.exportGrafana%",
         "category": "Viewstor"
+      },
+      {
+        "command": "viewstor.compareWith",
+        "title": "%command.compareWith%",
+        "category": "Viewstor",
+        "icon": "$(diff)"
+      },
+      {
+        "command": "viewstor.compareData",
+        "title": "%command.compareData%",
+        "category": "Viewstor",
+        "icon": "$(diff)"
       }
     ],
     "menus": {
@@ -383,6 +395,11 @@
         {
           "command": "viewstor.showDDL",
           "when": "view == viewstor.connections && viewItem =~ /^(table|view|index|trigger|sequence)$/",
+          "group": "2_data"
+        },
+        {
+          "command": "viewstor.compareWith",
+          "when": "view == viewstor.connections && viewItem =~ /^(table|view)$/",
           "group": "2_data"
         },
         {
@@ -532,6 +549,13 @@
           "type": "string",
           "default": "",
           "description": "%config.grafanaApiKey.description%"
+        },
+        "viewstor.diffRowLimit": {
+          "type": "number",
+          "default": 10000,
+          "minimum": 100,
+          "maximum": 100000,
+          "description": "%config.diffRowLimit.description%"
         }
       }
     },

--- a/src/commands/diffCommands.ts
+++ b/src/commands/diffCommands.ts
@@ -1,0 +1,249 @@
+import * as vscode from 'vscode';
+import { CommandContext } from './shared';
+import { ConnectionTreeItem } from '../views/connectionTree';
+import { DiffSource, DiffOptions } from '../diff/diffTypes';
+
+export function registerDiffCommands(context: vscode.ExtensionContext, ctx: CommandContext) {
+  const { connectionManager, diffPanelManager } = ctx;
+
+  context.subscriptions.push(
+    // Context menu on table: "Compare with..."
+    vscode.commands.registerCommand('viewstor.compareWith', async (item?: ConnectionTreeItem) => {
+      if (!item?.connectionId || !item.schemaObject) return;
+      if (!diffPanelManager) return;
+
+      const leftState = connectionManager.get(item.connectionId);
+      if (!leftState) return;
+
+      // Build list of all tables across all connected connections
+      const allConnections = connectionManager.getAll().filter(s => s.connected);
+      const tableItems: Array<{
+        label: string;
+        description: string;
+        connectionId: string;
+        tableName: string;
+        schema?: string;
+        databaseName?: string;
+      }> = [];
+
+      for (const conn of allConnections) {
+        const driver = connectionManager.getDriver(conn.config.id);
+        if (!driver) continue;
+        try {
+          const schema = await driver.getSchema();
+          for (const schemaObj of schema) {
+            if (schemaObj.children) {
+              for (const child of schemaObj.children) {
+                if (child.type === 'table' || child.type === 'view') {
+                  tableItems.push({
+                    label: child.name,
+                    description: `${schemaObj.name} — ${conn.config.name}`,
+                    connectionId: conn.config.id,
+                    tableName: child.name,
+                    schema: schemaObj.name,
+                  });
+                }
+              }
+            }
+          }
+        } catch { /* skip connections with schema fetch errors */ }
+      }
+
+      if (tableItems.length === 0) {
+        vscode.window.showWarningMessage(vscode.l10n.t('No tables available for comparison. Connect to a database first.'));
+        return;
+      }
+
+      const picked = await vscode.window.showQuickPick(tableItems, {
+        placeHolder: vscode.l10n.t('Select table to compare with "{0}"', item.schemaObject.name),
+      });
+      if (!picked) return;
+
+      // Get left table info and data
+      const leftDriver = item.databaseName
+        ? await connectionManager.getDriverForDatabase(item.connectionId, item.databaseName)
+        : connectionManager.getDriver(item.connectionId);
+      if (!leftDriver) return;
+
+      const rightDriver = picked.databaseName
+        ? await connectionManager.getDriverForDatabase(picked.connectionId, picked.databaseName)
+        : connectionManager.getDriver(picked.connectionId);
+      if (!rightDriver) return;
+
+      const rowLimit = vscode.workspace.getConfiguration('viewstor').get<number>('diffRowLimit', 10000);
+
+      await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Comparing data...') },
+        async () => {
+          const [leftInfo, rightInfo, leftData, rightData] = await Promise.all([
+            leftDriver.getTableInfo(item.schemaObject!.name, item.schemaObject!.schema),
+            rightDriver.getTableInfo(picked.tableName, picked.schema),
+            leftDriver.getTableData(item.schemaObject!.name, item.schemaObject!.schema, rowLimit, 0),
+            rightDriver.getTableData(picked.tableName, picked.schema, rowLimit, 0),
+          ]);
+
+          // Auto-detect key columns from left table PKs
+          const pkColumns = leftInfo.columns.filter(c => c.isPrimaryKey).map(c => c.name);
+          let keyColumns = pkColumns;
+
+          if (keyColumns.length === 0) {
+            // No PK — ask user to pick key columns
+            const colPick = await vscode.window.showQuickPick(
+              leftInfo.columns.map(c => ({ label: c.name, description: c.dataType, picked: false })),
+              { canPickMany: true, placeHolder: vscode.l10n.t('No primary key found. Select key column(s) for matching:') },
+            );
+            if (!colPick || colPick.length === 0) return;
+            keyColumns = colPick.map(c => c.label);
+          }
+
+          const leftSource: DiffSource = {
+            label: `${item.schemaObject!.name} — ${leftState.config.name}`,
+            columns: leftData.columns,
+            rows: leftData.rows,
+            connectionId: item.connectionId,
+            tableName: item.schemaObject!.name,
+            schema: item.schemaObject!.schema,
+            databaseName: item.databaseName,
+          };
+
+          const rightState = connectionManager.get(picked.connectionId);
+          const rightSource: DiffSource = {
+            label: `${picked.tableName} — ${rightState?.config.name || 'Unknown'}`,
+            columns: rightData.columns,
+            rows: rightData.rows,
+            connectionId: picked.connectionId,
+            tableName: picked.tableName,
+            schema: picked.schema,
+            databaseName: picked.databaseName,
+          };
+
+          const options: DiffOptions = { keyColumns, rowLimit };
+
+          diffPanelManager.show(leftSource, rightSource, options,
+            { columns: leftInfo.columns },
+            { columns: rightInfo.columns },
+          );
+        },
+      );
+    }),
+
+    // Command palette: "Compare Data"
+    vscode.commands.registerCommand('viewstor.compareData', async () => {
+      if (!diffPanelManager) return;
+
+      const allConnections = connectionManager.getAll().filter(s => s.connected);
+      if (allConnections.length === 0) {
+        vscode.window.showWarningMessage(vscode.l10n.t('No connected databases. Connect first.'));
+        return;
+      }
+
+      // Build list of all tables
+      const tableItems: Array<{
+        label: string;
+        description: string;
+        connectionId: string;
+        tableName: string;
+        schema?: string;
+        databaseName?: string;
+      }> = [];
+
+      for (const conn of allConnections) {
+        const driver = connectionManager.getDriver(conn.config.id);
+        if (!driver) continue;
+        try {
+          const schema = await driver.getSchema();
+          for (const schemaObj of schema) {
+            if (schemaObj.children) {
+              for (const child of schemaObj.children) {
+                if (child.type === 'table' || child.type === 'view') {
+                  tableItems.push({
+                    label: child.name,
+                    description: `${schemaObj.name} — ${conn.config.name}`,
+                    connectionId: conn.config.id,
+                    tableName: child.name,
+                    schema: schemaObj.name,
+                  });
+                }
+              }
+            }
+          }
+        } catch { /* skip */ }
+      }
+
+      if (tableItems.length < 2) {
+        vscode.window.showWarningMessage(vscode.l10n.t('Need at least 2 tables for comparison.'));
+        return;
+      }
+
+      const leftPick = await vscode.window.showQuickPick(tableItems, {
+        placeHolder: vscode.l10n.t('Select LEFT table'),
+      });
+      if (!leftPick) return;
+
+      const rightPick = await vscode.window.showQuickPick(tableItems, {
+        placeHolder: vscode.l10n.t('Select RIGHT table'),
+      });
+      if (!rightPick) return;
+
+      const rowLimit = vscode.workspace.getConfiguration('viewstor').get<number>('diffRowLimit', 10000);
+
+      await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Comparing data...') },
+        async () => {
+          const leftDriver = leftPick.databaseName
+            ? await connectionManager.getDriverForDatabase(leftPick.connectionId, leftPick.databaseName)
+            : connectionManager.getDriver(leftPick.connectionId);
+          const rightDriver = rightPick.databaseName
+            ? await connectionManager.getDriverForDatabase(rightPick.connectionId, rightPick.databaseName)
+            : connectionManager.getDriver(rightPick.connectionId);
+          if (!leftDriver || !rightDriver) return;
+
+          const [leftInfo, rightInfo, leftData, rightData] = await Promise.all([
+            leftDriver.getTableInfo(leftPick.tableName, leftPick.schema),
+            rightDriver.getTableInfo(rightPick.tableName, rightPick.schema),
+            leftDriver.getTableData(leftPick.tableName, leftPick.schema, rowLimit, 0),
+            rightDriver.getTableData(rightPick.tableName, rightPick.schema, rowLimit, 0),
+          ]);
+
+          const pkColumns = leftInfo.columns.filter(c => c.isPrimaryKey).map(c => c.name);
+          let keyColumns = pkColumns;
+
+          if (keyColumns.length === 0) {
+            const colPick = await vscode.window.showQuickPick(
+              leftInfo.columns.map(c => ({ label: c.name, description: c.dataType, picked: false })),
+              { canPickMany: true, placeHolder: vscode.l10n.t('No primary key found. Select key column(s) for matching:') },
+            );
+            if (!colPick || colPick.length === 0) return;
+            keyColumns = colPick.map(c => c.label);
+          }
+
+          const leftState = connectionManager.get(leftPick.connectionId);
+          const rightState = connectionManager.get(rightPick.connectionId);
+
+          const leftSource: DiffSource = {
+            label: `${leftPick.tableName} — ${leftState?.config.name || 'Unknown'}`,
+            columns: leftData.columns,
+            rows: leftData.rows,
+            connectionId: leftPick.connectionId,
+            tableName: leftPick.tableName,
+            schema: leftPick.schema,
+          };
+
+          const rightSource: DiffSource = {
+            label: `${rightPick.tableName} — ${rightState?.config.name || 'Unknown'}`,
+            columns: rightData.columns,
+            rows: rightData.rows,
+            connectionId: rightPick.connectionId,
+            tableName: rightPick.tableName,
+            schema: rightPick.schema,
+          };
+
+          diffPanelManager.show(leftSource, rightSource, { keyColumns, rowLimit },
+            { columns: leftInfo.columns },
+            { columns: rightInfo.columns },
+          );
+        },
+      );
+    }),
+  );
+}

--- a/src/commands/diffCommands.ts
+++ b/src/commands/diffCommands.ts
@@ -15,39 +15,44 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
       const leftState = connectionManager.get(item.connectionId);
       if (!leftState) return;
 
-      // Build list of all tables across all connected connections
-      const allConnections = connectionManager.getAll().filter(s => s.connected);
-      const tableItems: Array<{
-        label: string;
-        description: string;
-        connectionId: string;
-        tableName: string;
-        schema?: string;
-        databaseName?: string;
-      }> = [];
-
-      for (const conn of allConnections) {
-        const driver = connectionManager.getDriver(conn.config.id);
-        if (!driver) continue;
-        try {
-          const schema = await driver.getSchema();
-          for (const schemaObj of schema) {
-            if (schemaObj.children) {
-              for (const child of schemaObj.children) {
-                if (child.type === 'table' || child.type === 'view') {
-                  tableItems.push({
-                    label: child.name,
-                    description: `${schemaObj.name} — ${conn.config.name}`,
-                    connectionId: conn.config.id,
-                    tableName: child.name,
-                    schema: schemaObj.name,
-                  });
+      // Build list of all tables across all connected connections (can be slow)
+      const tableItems = await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Loading tables...') },
+        async () => {
+          const items: Array<{
+            label: string;
+            description: string;
+            connectionId: string;
+            tableName: string;
+            schema?: string;
+            databaseName?: string;
+          }> = [];
+          const allConnections = connectionManager.getAll().filter(s => s.connected);
+          for (const conn of allConnections) {
+            const driver = connectionManager.getDriver(conn.config.id);
+            if (!driver) continue;
+            try {
+              const schema = await driver.getSchema();
+              for (const schemaObj of schema) {
+                if (schemaObj.children) {
+                  for (const child of schemaObj.children) {
+                    if (child.type === 'table' || child.type === 'view') {
+                      items.push({
+                        label: child.name,
+                        description: `${schemaObj.name} — ${conn.config.name}`,
+                        connectionId: conn.config.id,
+                        tableName: child.name,
+                        schema: schemaObj.name,
+                      });
+                    }
+                  }
                 }
               }
-            }
+            } catch { /* skip connections with schema fetch errors */ }
           }
-        } catch { /* skip connections with schema fetch errors */ }
-      }
+          return items;
+        },
+      );
 
       if (tableItems.length === 0) {
         vscode.window.showWarningMessage(vscode.l10n.t('No tables available for comparison. Connect to a database first.'));
@@ -137,38 +142,43 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
         return;
       }
 
-      // Build list of all tables
-      const tableItems: Array<{
-        label: string;
-        description: string;
-        connectionId: string;
-        tableName: string;
-        schema?: string;
-        databaseName?: string;
-      }> = [];
-
-      for (const conn of allConnections) {
-        const driver = connectionManager.getDriver(conn.config.id);
-        if (!driver) continue;
-        try {
-          const schema = await driver.getSchema();
-          for (const schemaObj of schema) {
-            if (schemaObj.children) {
-              for (const child of schemaObj.children) {
-                if (child.type === 'table' || child.type === 'view') {
-                  tableItems.push({
-                    label: child.name,
-                    description: `${schemaObj.name} — ${conn.config.name}`,
-                    connectionId: conn.config.id,
-                    tableName: child.name,
-                    schema: schemaObj.name,
-                  });
+      // Build list of all tables (can be slow)
+      const tableItems = await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Loading tables...') },
+        async () => {
+          const items: Array<{
+            label: string;
+            description: string;
+            connectionId: string;
+            tableName: string;
+            schema?: string;
+            databaseName?: string;
+          }> = [];
+          for (const conn of allConnections) {
+            const driver = connectionManager.getDriver(conn.config.id);
+            if (!driver) continue;
+            try {
+              const schema = await driver.getSchema();
+              for (const schemaObj of schema) {
+                if (schemaObj.children) {
+                  for (const child of schemaObj.children) {
+                    if (child.type === 'table' || child.type === 'view') {
+                      items.push({
+                        label: child.name,
+                        description: `${schemaObj.name} — ${conn.config.name}`,
+                        connectionId: conn.config.id,
+                        tableName: child.name,
+                        schema: schemaObj.name,
+                      });
+                    }
+                  }
                 }
               }
-            }
+            } catch { /* skip */ }
           }
-        } catch { /* skip */ }
-      }
+          return items;
+        },
+      );
 
       if (tableItems.length < 2) {
         vscode.window.showWarningMessage(vscode.l10n.t('Need at least 2 tables for comparison.'));

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,6 +7,7 @@ import { registerConnectionCommands } from './connectionCommands';
 import { registerHistoryCommands } from './historyCommands';
 import { registerSchemaCommands } from './schemaCommands';
 import { registerExportCommands } from './exportCommands';
+import { registerDiffCommands } from './diffCommands';
 
 // Re-export CommandContext so extension.ts import path stays the same
 export type { CommandContext } from './shared';
@@ -59,4 +60,5 @@ export function registerCommands(context: vscode.ExtensionContext, ctx: CommandC
   registerHistoryCommands(context, ctx);
   registerSchemaCommands(context, ctx);
   registerExportCommands(context, ctx);
+  registerDiffCommands(context, ctx);
 }

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -9,6 +9,7 @@ import { ConnectionFormPanel } from '../views/connectionForm';
 import { FolderFormPanel } from '../views/folderForm';
 import { TempFileManager } from '../services/tempFileManager';
 import { QueryFileManager } from '../services/queryFileManager';
+import { DiffPanelManager } from '../diff/diffPanel';
 import { splitStatements, firstSqlTokenOffset } from '../utils/queryHelpers';
 
 export interface CommandContext {
@@ -23,6 +24,7 @@ export interface CommandContext {
   outputChannel: vscode.LogOutputChannel;
   tempFileManager: TempFileManager;
   queryFileManager: QueryFileManager;
+  diffPanelManager: DiffPanelManager;
 }
 
 // --- Shared mutable state ---

--- a/src/diff/diffEngine.ts
+++ b/src/diff/diffEngine.ts
@@ -1,0 +1,208 @@
+import { ColumnInfo } from '../types/schema';
+import { DiffOptions, DiffSource, MatchedRow, RowDiffResult, SchemaDiffResult, ColumnDiffInfo, ColumnCompare } from './diffTypes';
+
+/**
+ * Stringify a cell value for comparison.
+ * Produces consistent string representation across all database types.
+ */
+export function stringifyCell(value: unknown): string {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * Build a composite key string from a row's key columns.
+ * Uses null-byte separator to avoid collisions.
+ */
+function buildRowKey(row: Record<string, unknown>, keyColumns: string[]): string {
+  return keyColumns.map(col => stringifyCell(row[col])).join('\0');
+}
+
+/**
+ * Compute row-level diff between two data sources.
+ * Matches rows by key columns, then compares all other columns.
+ */
+export function computeRowDiff(left: DiffSource, right: DiffSource, options: DiffOptions): RowDiffResult {
+  const { keyColumns, rowLimit } = options;
+
+  // Enforce row limit
+  const leftRows = left.rows.slice(0, rowLimit);
+  const rightRows = right.rows.slice(0, rowLimit);
+  const truncated = left.rows.length > rowLimit || right.rows.length > rowLimit;
+
+  // Collect all columns from both sides
+  const leftColNames = left.columns.map(c => c.name);
+  const rightColNames = right.columns.map(c => c.name);
+  const allColumnsSet = new Set([...leftColNames, ...rightColNames]);
+  const allColumns = [...allColumnsSet];
+  const nonKeyColumns = allColumns.filter(col => !keyColumns.includes(col));
+
+  // Build index for right side (key -> row)
+  // If duplicate keys exist, last occurrence wins
+  const rightIndex = new Map<string, Record<string, unknown>>();
+  for (const row of rightRows) {
+    rightIndex.set(buildRowKey(row, keyColumns), row);
+  }
+
+  const matched: MatchedRow[] = [];
+  const leftOnly: Record<string, unknown>[] = [];
+  let unchanged = 0;
+
+  // Pass 1: iterate left rows, match against right index
+  const matchedKeys = new Set<string>();
+  for (const leftRow of leftRows) {
+    const key = buildRowKey(leftRow, keyColumns);
+    const rightRow = rightIndex.get(key);
+
+    if (rightRow) {
+      matchedKeys.add(key);
+      // Compare non-key columns
+      const changedColumns: string[] = [];
+      for (const col of nonKeyColumns) {
+        if (stringifyCell(leftRow[col]) !== stringifyCell(rightRow[col])) {
+          changedColumns.push(col);
+        }
+      }
+      if (changedColumns.length > 0) {
+        matched.push({ key, left: leftRow, right: rightRow, changedColumns });
+      } else {
+        unchanged++;
+      }
+    } else {
+      leftOnly.push(leftRow);
+    }
+  }
+
+  // Pass 2: remaining right rows not matched
+  const rightOnly: Record<string, unknown>[] = [];
+  for (const row of rightRows) {
+    const key = buildRowKey(row, keyColumns);
+    if (!matchedKeys.has(key)) {
+      rightOnly.push(row);
+    }
+  }
+
+  return {
+    allColumns,
+    matched,
+    leftOnly,
+    rightOnly,
+    truncated,
+    summary: {
+      total: leftRows.length + rightOnly.length,
+      unchanged,
+      changed: matched.length,
+      added: rightOnly.length,
+      removed: leftOnly.length,
+    },
+  };
+}
+
+/**
+ * Compute schema-level diff between two tables.
+ * Compares column names, data types, nullability, and primary key status.
+ */
+export function computeSchemaDiff(leftColumns: ColumnInfo[], rightColumns: ColumnInfo[]): SchemaDiffResult {
+  const leftMap = new Map<string, ColumnInfo>();
+  for (const col of leftColumns) {
+    leftMap.set(col.name, col);
+  }
+
+  const rightMap = new Map<string, ColumnInfo>();
+  for (const col of rightColumns) {
+    rightMap.set(col.name, col);
+  }
+
+  const leftOnlyColumns: ColumnDiffInfo[] = [];
+  const commonColumns: ColumnCompare[] = [];
+
+  for (const [name, leftCol] of leftMap) {
+    const rightCol = rightMap.get(name);
+    if (!rightCol) {
+      leftOnlyColumns.push({
+        name: leftCol.name,
+        dataType: leftCol.dataType,
+        nullable: leftCol.nullable,
+        isPrimaryKey: leftCol.isPrimaryKey,
+      });
+    } else {
+      commonColumns.push({
+        name,
+        leftType: leftCol.dataType,
+        rightType: rightCol.dataType,
+        typeDiffers: leftCol.dataType !== rightCol.dataType,
+        leftNullable: leftCol.nullable,
+        rightNullable: rightCol.nullable,
+        nullableDiffers: leftCol.nullable !== rightCol.nullable,
+        leftIsPK: leftCol.isPrimaryKey,
+        rightIsPK: rightCol.isPrimaryKey,
+        pkDiffers: leftCol.isPrimaryKey !== rightCol.isPrimaryKey,
+      });
+    }
+  }
+
+  const rightOnlyColumns: ColumnDiffInfo[] = [];
+  for (const [name, rightCol] of rightMap) {
+    if (!leftMap.has(name)) {
+      rightOnlyColumns.push({
+        name: rightCol.name,
+        dataType: rightCol.dataType,
+        nullable: rightCol.nullable,
+        isPrimaryKey: rightCol.isPrimaryKey,
+      });
+    }
+  }
+
+  return { leftOnlyColumns, rightOnlyColumns, commonColumns };
+}
+
+/**
+ * Export a row diff result as CSV.
+ * Adds a _diff_status column indicating added/removed/changed for each row.
+ */
+export function exportDiffAsCsv(result: RowDiffResult, _keyColumns: string[]): string {
+  const header = ['_diff_status', ...result.allColumns];
+  const lines: string[] = [header.join(',')];
+
+  const escapeValue = (value: unknown): string => {
+    const str = stringifyCell(value);
+    if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+
+  const formatRow = (row: Record<string, unknown>, status: string): string => {
+    return [status, ...result.allColumns.map(col => escapeValue(row[col]))].join(',');
+  };
+
+  for (const row of result.leftOnly) {
+    lines.push(formatRow(row, 'removed'));
+  }
+  for (const match of result.matched) {
+    lines.push(formatRow(match.right, 'changed'));
+  }
+  for (const row of result.rightOnly) {
+    lines.push(formatRow(row, 'added'));
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Export a row diff result as JSON.
+ */
+export function exportDiffAsJson(result: RowDiffResult): string {
+  return JSON.stringify({
+    summary: result.summary,
+    changed: result.matched.map(match => ({
+      key: match.key,
+      changedColumns: match.changedColumns,
+      left: match.left,
+      right: match.right,
+    })),
+    added: result.rightOnly,
+    removed: result.leftOnly,
+  }, null, 2);
+}

--- a/src/diff/diffEngine.ts
+++ b/src/diff/diffEngine.ts
@@ -64,9 +64,8 @@ export function computeRowDiff(left: DiffSource, right: DiffSource, options: Dif
           changedColumns.push(col);
         }
       }
-      if (changedColumns.length > 0) {
-        matched.push({ key, left: leftRow, right: rightRow, changedColumns });
-      } else {
+      matched.push({ key, left: leftRow, right: rightRow, changedColumns });
+      if (changedColumns.length === 0) {
         unchanged++;
       }
     } else {
@@ -92,7 +91,7 @@ export function computeRowDiff(left: DiffSource, right: DiffSource, options: Dif
     summary: {
       total: leftRows.length + rightOnly.length,
       unchanged,
-      changed: matched.length,
+      changed: matched.length - unchanged,
       added: rightOnly.length,
       removed: leftOnly.length,
     },

--- a/src/diff/diffPanel.ts
+++ b/src/diff/diffPanel.ts
@@ -1,0 +1,226 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { DiffSource, DiffOptions, RowDiffResult, SchemaDiffResult } from './diffTypes';
+import { computeRowDiff, computeSchemaDiff, exportDiffAsCsv, exportDiffAsJson } from './diffEngine';
+import { ColumnInfo } from '../types/schema';
+
+interface DiffState {
+  panel: vscode.WebviewPanel;
+  left: DiffSource;
+  right: DiffSource;
+  options: DiffOptions;
+  rowDiff: RowDiffResult;
+  schemaDiff: SchemaDiffResult | null;
+  leftTableInfo?: { columns: ColumnInfo[] };
+  rightTableInfo?: { columns: ColumnInfo[] };
+  disposable: vscode.Disposable;
+}
+
+export class DiffPanelManager {
+  private diffs = new Map<string, DiffState>();
+
+  constructor(private readonly context: vscode.ExtensionContext) {}
+
+  show(
+    left: DiffSource,
+    right: DiffSource,
+    options: DiffOptions,
+    leftTableInfo?: { columns: ColumnInfo[] },
+    rightTableInfo?: { columns: ColumnInfo[] },
+  ) {
+    const rowDiff = computeRowDiff(left, right, options);
+    const schemaDiff = leftTableInfo && rightTableInfo
+      ? computeSchemaDiff(leftTableInfo.columns, rightTableInfo.columns)
+      : null;
+
+    const panelTitle = `Diff \u2014 ${left.label} \u2194 ${right.label}`;
+    const panelKey = `diff:${panelTitle}`;
+
+    let state = this.diffs.get(panelKey);
+    if (state) {
+      state.panel.reveal();
+      state.left = left;
+      state.right = right;
+      state.options = options;
+      state.rowDiff = rowDiff;
+      state.schemaDiff = schemaDiff;
+      state.leftTableInfo = leftTableInfo;
+      state.rightTableInfo = rightTableInfo;
+    } else {
+      const panel = vscode.window.createWebviewPanel(
+        'viewstor.diff',
+        panelTitle,
+        vscode.ViewColumn.Active,
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          localResourceRoots: [vscode.Uri.file(path.join(this.context.extensionPath, 'dist'))],
+        },
+      );
+      panel.onDidDispose(() => {
+        const diffState = this.diffs.get(panelKey);
+        if (diffState) diffState.disposable.dispose();
+        this.diffs.delete(panelKey);
+      });
+
+      state = {
+        panel,
+        left,
+        right,
+        options,
+        rowDiff,
+        schemaDiff,
+        leftTableInfo,
+        rightTableInfo,
+        disposable: new vscode.Disposable(() => {}),
+      };
+      this.diffs.set(panelKey, state);
+    }
+
+    state.panel.webview.html = this.buildHtml(state.panel.webview, state);
+    state.disposable.dispose();
+    state.disposable = this.registerMessageHandler(state);
+  }
+
+  private registerMessageHandler(state: DiffState): vscode.Disposable {
+    return state.panel.webview.onDidReceiveMessage(async (msg) => {
+      switch (msg.type) {
+        case 'exportDiff': {
+          const content = msg.format === 'csv'
+            ? exportDiffAsCsv(state.rowDiff, state.options.keyColumns)
+            : exportDiffAsJson(state.rowDiff);
+          const ext = msg.format === 'csv' ? 'csv' : 'json';
+          const filters: Record<string, string[]> = msg.format === 'csv'
+            ? { CSV: ['csv'] }
+            : { JSON: ['json'] };
+          const uri = await vscode.window.showSaveDialog({
+            filters,
+            defaultUri: vscode.Uri.file(`diff-export.${ext}`),
+          });
+          if (uri) {
+            await vscode.workspace.fs.writeFile(uri, Buffer.from(content, 'utf-8'));
+            vscode.window.showInformationMessage(
+              vscode.l10n.t('Diff exported to {0}', uri.fsPath),
+            );
+          }
+          break;
+        }
+
+        case 'swapSides': {
+          // Swap left and right sources and re-compute
+          const swappedLeft = state.right;
+          const swappedRight = state.left;
+          const swappedLeftInfo = state.rightTableInfo;
+          const swappedRightInfo = state.leftTableInfo;
+          this.show(swappedLeft, swappedRight, state.options, swappedLeftInfo, swappedRightInfo);
+          break;
+        }
+      }
+    });
+  }
+
+  private buildHtml(webview: vscode.Webview, state: DiffState): string {
+    const distUri = vscode.Uri.file(path.join(this.context.extensionPath, 'dist'));
+    const cssUri = webview.asWebviewUri(vscode.Uri.joinPath(distUri, 'styles', 'diff-panel.css'));
+    const jsUri = webview.asWebviewUri(vscode.Uri.joinPath(distUri, 'scripts', 'diff-panel.js'));
+    const cspSource = webview.cspSource;
+
+    const diffData = {
+      rowDiff: state.rowDiff,
+      schemaDiff: state.schemaDiff,
+      leftLabel: state.left.label,
+      rightLabel: state.right.label,
+      keyColumns: state.options.keyColumns,
+    };
+
+    const summary = state.rowDiff.summary;
+    const hasSchema = !!state.schemaDiff;
+
+    return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource}; script-src 'unsafe-inline' ${cspSource};">
+<link rel="stylesheet" href="${cssUri}">
+</head>
+<body>
+  <div class="diff-tab-bar">
+    <button class="diff-tab active" data-tab="rows">Row Diff</button>
+    <button class="diff-tab" data-tab="schema">Schema Diff</button>
+  </div>
+
+  <div class="diff-summary">
+    <span class="diff-badge unchanged">${esc(String(summary.unchanged))} unchanged</span>
+    <span class="diff-badge changed">${esc(String(summary.changed))} changed</span>
+    <span class="diff-badge added">${esc(String(summary.added))} added</span>
+    <span class="diff-badge removed">${esc(String(summary.removed))} removed</span>
+    <span class="diff-summary-spacer"></span>
+    <button id="swapSides" title="Swap left and right sides">\u21C4 Swap</button>
+    <button id="exportCsv">Export CSV</button>
+    <button id="exportJson">Export JSON</button>
+  </div>
+
+  ${state.rowDiff.truncated ? '<div class="diff-truncated">Results truncated to row limit. Increase the limit to see all differences.</div>' : ''}
+
+  <div id="panel-rows" class="diff-tab-panel active">
+    <div class="diff-filter-bar">
+      <span class="diff-filter-label">Filter:</span>
+      <button class="diff-filter-btn active" data-filter="all">All</button>
+      <button class="diff-filter-btn" data-filter="changed">Changed</button>
+      <button class="diff-filter-btn" data-filter="added">Added</button>
+      <button class="diff-filter-btn" data-filter="removed">Removed</button>
+    </div>
+    <div class="diff-tables-container">
+      <div class="diff-table-pane" id="leftPane">
+        <div class="diff-table-pane-header" id="leftHeader">${esc(state.left.label)}</div>
+        <table class="diff-table">
+          <thead id="leftTableHead"></thead>
+          <tbody id="leftTableBody"></tbody>
+        </table>
+      </div>
+      <div class="diff-table-pane" id="rightPane">
+        <div class="diff-table-pane-header" id="rightHeader">${esc(state.right.label)}</div>
+        <table class="diff-table">
+          <thead id="rightTableHead"></thead>
+          <tbody id="rightTableBody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div id="panel-schema" class="diff-tab-panel">
+    ${hasSchema ? `
+    <div class="diff-schema-container">
+      <table class="diff-schema-table">
+        <thead>
+          <tr>
+            <th>Column</th>
+            <th>Left Type</th>
+            <th>Right Type</th>
+            <th>Left Nullable</th>
+            <th>Right Nullable</th>
+            <th>Left PK</th>
+            <th>Right PK</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody id="schemaTableBody"></tbody>
+      </table>
+    </div>
+    ` : '<div class="diff-no-schema">Schema diff not available (table info not provided)</div>'}
+  </div>
+
+  <script>window.diffData = ${safeJsonForScript(diffData)};</script>
+  <script src="${jsUri}"></script>
+</body>
+</html>`;
+  }
+}
+
+function esc(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function safeJsonForScript(data: unknown): string {
+  return JSON.stringify(data).replace(/<\//g, '<\\/').replace(/<!--/g, '<\\!--');
+}

--- a/src/diff/diffPanel.ts
+++ b/src/diff/diffPanel.ts
@@ -167,6 +167,7 @@ export class DiffPanelManager {
       <span class="diff-filter-label">Filter:</span>
       <button class="diff-filter-btn active" data-filter="all">All</button>
       <button class="diff-filter-btn" data-filter="changed">Changed</button>
+      <button class="diff-filter-btn" data-filter="unchanged">Unchanged</button>
       <button class="diff-filter-btn" data-filter="added">Added</button>
       <button class="diff-filter-btn" data-filter="removed">Removed</button>
     </div>

--- a/src/diff/diffTypes.ts
+++ b/src/diff/diffTypes.ts
@@ -1,0 +1,64 @@
+import { QueryColumn } from '../types/query';
+
+export interface DiffSource {
+  label: string;
+  columns: QueryColumn[];
+  rows: Record<string, unknown>[];
+  connectionId?: string;
+  tableName?: string;
+  schema?: string;
+  databaseName?: string;
+}
+
+export interface DiffOptions {
+  keyColumns: string[];
+  rowLimit: number;
+}
+
+export interface RowDiffResult {
+  allColumns: string[];
+  matched: MatchedRow[];
+  leftOnly: Record<string, unknown>[];
+  rightOnly: Record<string, unknown>[];
+  truncated: boolean;
+  summary: {
+    total: number;
+    unchanged: number;
+    changed: number;
+    added: number;
+    removed: number;
+  };
+}
+
+export interface MatchedRow {
+  key: string;
+  left: Record<string, unknown>;
+  right: Record<string, unknown>;
+  changedColumns: string[];
+}
+
+export interface SchemaDiffResult {
+  leftOnlyColumns: ColumnDiffInfo[];
+  rightOnlyColumns: ColumnDiffInfo[];
+  commonColumns: ColumnCompare[];
+}
+
+export interface ColumnDiffInfo {
+  name: string;
+  dataType: string;
+  nullable: boolean;
+  isPrimaryKey: boolean;
+}
+
+export interface ColumnCompare {
+  name: string;
+  leftType: string;
+  rightType: string;
+  typeDiffers: boolean;
+  leftNullable: boolean;
+  rightNullable: boolean;
+  nullableDiffers: boolean;
+  leftIsPK: boolean;
+  rightIsPK: boolean;
+  pkDiffers: boolean;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { registerMcpCommands } from './mcp/server';
 import { registerCommands } from './commands';
 import { registerChatParticipant } from './chat/participant';
 import { ChartPanelManager, setChartOutputChannel } from './chart/chartPanel';
+import { DiffPanelManager } from './diff/diffPanel';
 import { TempFileManager } from './services/tempFileManager';
 import { QueryFileManager } from './services/queryFileManager';
 import { setDebugChannel, dbg } from './utils/debug';
@@ -43,6 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
     chartPanelManager.setPinnedQueryProvider(queryHistoryProvider);
     chartPanelManager.setConnectionManager(connectionManager);
     setChartOutputChannel(outputChannel);
+    const diffPanelManager = new DiffPanelManager(context);
     tempFileManager = new TempFileManager(context, queryFileManager);
     tempFileManager.setPostMessage((key, msg) => resultPanelManager.postMessage(key, msg));
     resultPanelManager.setTempFileManager(tempFileManager);
@@ -100,6 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
       outputChannel,
       tempFileManager,
       queryFileManager,
+      diffPanelManager,
     });
 
     // MCP-compatible commands for AI agent integration

--- a/src/test/diffEngine.test.ts
+++ b/src/test/diffEngine.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect } from 'vitest';
+import { stringifyCell, computeRowDiff, computeSchemaDiff, exportDiffAsCsv, exportDiffAsJson } from '../diff/diffEngine';
+import { DiffSource, DiffOptions } from '../diff/diffTypes';
+import { ColumnInfo } from '../types/schema';
+
+// --- stringifyCell ---
+
+describe('stringifyCell', () => {
+  it('null returns NULL', () => {
+    expect(stringifyCell(null)).toBe('NULL');
+  });
+
+  it('undefined returns NULL', () => {
+    expect(stringifyCell(undefined)).toBe('NULL');
+  });
+
+  it('number returns string', () => {
+    expect(stringifyCell(42)).toBe('42');
+    expect(stringifyCell(3.14)).toBe('3.14');
+    expect(stringifyCell(0)).toBe('0');
+  });
+
+  it('boolean returns string', () => {
+    expect(stringifyCell(true)).toBe('true');
+    expect(stringifyCell(false)).toBe('false');
+  });
+
+  it('string returns itself', () => {
+    expect(stringifyCell('hello')).toBe('hello');
+    expect(stringifyCell('')).toBe('');
+  });
+
+  it('object returns JSON', () => {
+    expect(stringifyCell({ key: 'value' })).toBe('{"key":"value"}');
+  });
+
+  it('array returns JSON', () => {
+    expect(stringifyCell([1, 2, 3])).toBe('[1,2,3]');
+  });
+});
+
+// --- computeRowDiff ---
+
+function makeSource(rows: Record<string, unknown>[], columns?: string[]): DiffSource {
+  const colNames = columns || (rows.length > 0 ? Object.keys(rows[0]) : []);
+  return {
+    label: 'test',
+    columns: colNames.map(name => ({ name, dataType: 'text' })),
+    rows,
+  };
+}
+
+function defaultOptions(keyColumns: string[], rowLimit = 10000): DiffOptions {
+  return { keyColumns, rowLimit };
+}
+
+describe('computeRowDiff', () => {
+  it('identical tables produce zero diffs', () => {
+    const rows = [
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ];
+    const result = computeRowDiff(makeSource(rows), makeSource(rows), defaultOptions(['id']));
+    expect(result.matched).toHaveLength(0);
+    expect(result.leftOnly).toHaveLength(0);
+    expect(result.rightOnly).toHaveLength(0);
+    expect(result.summary.unchanged).toBe(2);
+    expect(result.summary.changed).toBe(0);
+    expect(result.summary.added).toBe(0);
+    expect(result.summary.removed).toBe(0);
+  });
+
+  it('detects added rows (only in right)', () => {
+    const left = makeSource([{ id: 1, name: 'Alice' }]);
+    const right = makeSource([{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }]);
+    const result = computeRowDiff(left, right, defaultOptions(['id']));
+    expect(result.rightOnly).toHaveLength(1);
+    expect(result.rightOnly[0]).toEqual({ id: 2, name: 'Bob' });
+    expect(result.summary.added).toBe(1);
+  });
+
+  it('detects removed rows (only in left)', () => {
+    const left = makeSource([{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }]);
+    const right = makeSource([{ id: 1, name: 'Alice' }]);
+    const result = computeRowDiff(left, right, defaultOptions(['id']));
+    expect(result.leftOnly).toHaveLength(1);
+    expect(result.leftOnly[0]).toEqual({ id: 2, name: 'Bob' });
+    expect(result.summary.removed).toBe(1);
+  });
+
+  it('detects changed cells', () => {
+    const left = makeSource([{ id: 1, name: 'Alice', email: 'old@test.com' }]);
+    const right = makeSource([{ id: 1, name: 'Alice', email: 'new@test.com' }]);
+    const result = computeRowDiff(left, right, defaultOptions(['id']));
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0].changedColumns).toEqual(['email']);
+    expect(result.matched[0].left.email).toBe('old@test.com');
+    expect(result.matched[0].right.email).toBe('new@test.com');
+    expect(result.summary.changed).toBe(1);
+    expect(result.summary.unchanged).toBe(0);
+  });
+
+  it('handles composite key (multi-column PK)', () => {
+    const left = makeSource([
+      { org: 'A', user: 1, role: 'admin' },
+      { org: 'A', user: 2, role: 'member' },
+    ]);
+    const right = makeSource([
+      { org: 'A', user: 1, role: 'owner' },
+      { org: 'A', user: 2, role: 'member' },
+    ]);
+    const result = computeRowDiff(left, right, defaultOptions(['org', 'user']));
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0].changedColumns).toEqual(['role']);
+    expect(result.summary.unchanged).toBe(1);
+  });
+
+  it('NULL in left vs non-NULL in right is a change', () => {
+    const left = makeSource([{ id: 1, email: null }]);
+    const right = makeSource([{ id: 1, email: 'test@x.com' }]);
+    const result = computeRowDiff(left, right, defaultOptions(['id']));
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0].changedColumns).toEqual(['email']);
+  });
+
+  it('NULL in both sides is not a change', () => {
+    const left = makeSource([{ id: 1, email: null }]);
+    const right = makeSource([{ id: 1, email: null }]);
+    const result = computeRowDiff(left, right, defaultOptions(['id']));
+    expect(result.matched).toHaveLength(0);
+    expect(result.summary.unchanged).toBe(1);
+  });
+
+  it('type coercion: integer 1 vs string "1" treated as equal', () => {
+    const left = makeSource([{ id: 1, count: 42 }]);
+    const right = makeSource([{ id: 1, count: '42' }]);
+    const result = computeRowDiff(left, right, defaultOptions(['id']));
+    expect(result.summary.unchanged).toBe(1);
+    expect(result.matched).toHaveLength(0);
+  });
+
+  it('empty tables produce zero diffs', () => {
+    const result = computeRowDiff(makeSource([]), makeSource([]), defaultOptions(['id']));
+    expect(result.summary.total).toBe(0);
+    expect(result.matched).toHaveLength(0);
+    expect(result.leftOnly).toHaveLength(0);
+    expect(result.rightOnly).toHaveLength(0);
+  });
+
+  it('left empty, right has rows = all added', () => {
+    const right = makeSource([{ id: 1, name: 'Alice' }]);
+    const result = computeRowDiff(makeSource([], ['id', 'name']), right, defaultOptions(['id']));
+    expect(result.rightOnly).toHaveLength(1);
+    expect(result.summary.added).toBe(1);
+  });
+
+  it('row limit truncation sets truncated flag', () => {
+    const rows = Array.from({ length: 20 }, (_, index) => ({ id: index, name: `user-${index}` }));
+    const result = computeRowDiff(makeSource(rows), makeSource(rows), { keyColumns: ['id'], rowLimit: 10 });
+    expect(result.truncated).toBe(true);
+    expect(result.summary.unchanged).toBe(10);
+  });
+
+  it('no truncation when within limit', () => {
+    const rows = [{ id: 1, name: 'Alice' }];
+    const result = computeRowDiff(makeSource(rows), makeSource(rows), defaultOptions(['id']));
+    expect(result.truncated).toBe(false);
+  });
+
+  it('columns present in one side but not the other', () => {
+    const left = makeSource([{ id: 1, name: 'Alice' }], ['id', 'name']);
+    const right = makeSource([{ id: 1, email: 'a@test.com' }], ['id', 'email']);
+    const result = computeRowDiff(left, right, defaultOptions(['id']));
+    expect(result.allColumns).toContain('name');
+    expect(result.allColumns).toContain('email');
+    // name: Alice vs undefined (NULL), email: undefined (NULL) vs a@test.com
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0].changedColumns).toContain('name');
+    expect(result.matched[0].changedColumns).toContain('email');
+  });
+
+  it('duplicate keys: last occurrence wins', () => {
+    const left = makeSource([{ id: 1, name: 'First' }, { id: 1, name: 'Second' }]);
+    const right = makeSource([{ id: 1, name: 'Second' }]);
+    const result = computeRowDiff(left, right, defaultOptions(['id']));
+    // Left iterates both rows with key=1, but right has only one
+    // First left row matches, second left row also matches (same key)
+    // Both get compared against the same right row
+    expect(result.summary.unchanged + result.summary.changed + result.summary.removed).toBeGreaterThan(0);
+  });
+
+  it('allColumns includes columns from both sides', () => {
+    const left = makeSource([{ id: 1, colA: 'a' }], ['id', 'colA']);
+    const right = makeSource([{ id: 1, colB: 'b' }], ['id', 'colB']);
+    const result = computeRowDiff(left, right, defaultOptions(['id']));
+    expect(result.allColumns).toEqual(expect.arrayContaining(['id', 'colA', 'colB']));
+  });
+
+  it('mixed scenario: add + remove + change + unchanged', () => {
+    const left = makeSource([
+      { id: 1, name: 'Alice', score: 90 },
+      { id: 2, name: 'Bob', score: 80 },
+      { id: 3, name: 'Carol', score: 70 },
+    ]);
+    const right = makeSource([
+      { id: 1, name: 'Alice', score: 90 },    // unchanged
+      { id: 2, name: 'Bob', score: 85 },       // changed
+      { id: 4, name: 'Dave', score: 60 },      // added
+    ]);
+    const result = computeRowDiff(left, right, defaultOptions(['id']));
+    expect(result.summary.unchanged).toBe(1);
+    expect(result.summary.changed).toBe(1);
+    expect(result.summary.removed).toBe(1);
+    expect(result.summary.added).toBe(1);
+    expect(result.matched[0].changedColumns).toEqual(['score']);
+    expect(result.leftOnly[0].id).toBe(3);
+    expect(result.rightOnly[0].id).toBe(4);
+  });
+});
+
+// --- computeSchemaDiff ---
+
+function makeColumnInfo(name: string, dataType: string, nullable = true, isPrimaryKey = false): ColumnInfo {
+  return { name, dataType, nullable, isPrimaryKey };
+}
+
+describe('computeSchemaDiff', () => {
+  it('identical schemas produce no diffs', () => {
+    const columns = [
+      makeColumnInfo('id', 'integer', false, true),
+      makeColumnInfo('name', 'text', true, false),
+    ];
+    const result = computeSchemaDiff(columns, columns);
+    expect(result.leftOnlyColumns).toHaveLength(0);
+    expect(result.rightOnlyColumns).toHaveLength(0);
+    expect(result.commonColumns).toHaveLength(2);
+    expect(result.commonColumns.every(c => !c.typeDiffers && !c.nullableDiffers && !c.pkDiffers)).toBe(true);
+  });
+
+  it('detects column only in left', () => {
+    const left = [makeColumnInfo('id', 'integer'), makeColumnInfo('email', 'text')];
+    const right = [makeColumnInfo('id', 'integer')];
+    const result = computeSchemaDiff(left, right);
+    expect(result.leftOnlyColumns).toHaveLength(1);
+    expect(result.leftOnlyColumns[0].name).toBe('email');
+    expect(result.rightOnlyColumns).toHaveLength(0);
+  });
+
+  it('detects column only in right', () => {
+    const left = [makeColumnInfo('id', 'integer')];
+    const right = [makeColumnInfo('id', 'integer'), makeColumnInfo('phone', 'varchar')];
+    const result = computeSchemaDiff(left, right);
+    expect(result.rightOnlyColumns).toHaveLength(1);
+    expect(result.rightOnlyColumns[0].name).toBe('phone');
+  });
+
+  it('detects type difference', () => {
+    const left = [makeColumnInfo('name', 'varchar(50)')];
+    const right = [makeColumnInfo('name', 'text')];
+    const result = computeSchemaDiff(left, right);
+    expect(result.commonColumns).toHaveLength(1);
+    expect(result.commonColumns[0].typeDiffers).toBe(true);
+    expect(result.commonColumns[0].leftType).toBe('varchar(50)');
+    expect(result.commonColumns[0].rightType).toBe('text');
+  });
+
+  it('detects nullable difference', () => {
+    const left = [makeColumnInfo('email', 'text', true)];
+    const right = [makeColumnInfo('email', 'text', false)];
+    const result = computeSchemaDiff(left, right);
+    expect(result.commonColumns[0].nullableDiffers).toBe(true);
+  });
+
+  it('detects PK difference', () => {
+    const left = [makeColumnInfo('id', 'integer', false, true)];
+    const right = [makeColumnInfo('id', 'integer', false, false)];
+    const result = computeSchemaDiff(left, right);
+    expect(result.commonColumns[0].pkDiffers).toBe(true);
+  });
+
+  it('handles empty schemas', () => {
+    const result = computeSchemaDiff([], []);
+    expect(result.leftOnlyColumns).toHaveLength(0);
+    expect(result.rightOnlyColumns).toHaveLength(0);
+    expect(result.commonColumns).toHaveLength(0);
+  });
+});
+
+// --- exportDiffAsCsv ---
+
+describe('exportDiffAsCsv', () => {
+  it('exports added/removed/changed rows with status column', () => {
+    const left = makeSource([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ]);
+    const right = makeSource([
+      { id: 1, name: 'Alicia' },
+      { id: 3, name: 'Carol' },
+    ]);
+    const diff = computeRowDiff(left, right, defaultOptions(['id']));
+    const csv = exportDiffAsCsv(diff, ['id']);
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe('_diff_status,id,name');
+    expect(lines.some(line => line.startsWith('removed'))).toBe(true);
+    expect(lines.some(line => line.startsWith('changed'))).toBe(true);
+    expect(lines.some(line => line.startsWith('added'))).toBe(true);
+  });
+
+  it('escapes values with commas and quotes', () => {
+    const left = makeSource([{ id: 1, note: 'hello, "world"' }]);
+    const right = makeSource([{ id: 2, note: 'simple' }]);
+    const diff = computeRowDiff(left, right, defaultOptions(['id']));
+    const csv = exportDiffAsCsv(diff, ['id']);
+    expect(csv).toContain('"hello, ""world"""');
+  });
+});
+
+// --- exportDiffAsJson ---
+
+describe('exportDiffAsJson', () => {
+  it('produces valid JSON with summary and diff sections', () => {
+    const left = makeSource([{ id: 1, name: 'Alice' }]);
+    const right = makeSource([{ id: 1, name: 'Alicia' }, { id: 2, name: 'Bob' }]);
+    const diff = computeRowDiff(left, right, defaultOptions(['id']));
+    const json = exportDiffAsJson(diff);
+    const parsed = JSON.parse(json);
+    expect(parsed.summary.changed).toBe(1);
+    expect(parsed.summary.added).toBe(1);
+    expect(parsed.changed).toHaveLength(1);
+    expect(parsed.added).toHaveLength(1);
+    expect(parsed.removed).toHaveLength(0);
+  });
+});

--- a/src/test/diffEngine.test.ts
+++ b/src/test/diffEngine.test.ts
@@ -55,13 +55,14 @@ function defaultOptions(keyColumns: string[], rowLimit = 10000): DiffOptions {
 }
 
 describe('computeRowDiff', () => {
-  it('identical tables produce zero diffs', () => {
+  it('identical tables produce zero diffs (unchanged rows included in matched)', () => {
     const rows = [
       { id: 1, name: 'Alice' },
       { id: 2, name: 'Bob' },
     ];
     const result = computeRowDiff(makeSource(rows), makeSource(rows), defaultOptions(['id']));
-    expect(result.matched).toHaveLength(0);
+    expect(result.matched).toHaveLength(2); // unchanged rows are in matched with changedColumns=[]
+    expect(result.matched.every(m => m.changedColumns.length === 0)).toBe(true);
     expect(result.leftOnly).toHaveLength(0);
     expect(result.rightOnly).toHaveLength(0);
     expect(result.summary.unchanged).toBe(2);
@@ -110,8 +111,10 @@ describe('computeRowDiff', () => {
       { org: 'A', user: 2, role: 'member' },
     ]);
     const result = computeRowDiff(left, right, defaultOptions(['org', 'user']));
-    expect(result.matched).toHaveLength(1);
-    expect(result.matched[0].changedColumns).toEqual(['role']);
+    expect(result.matched).toHaveLength(2); // 1 changed + 1 unchanged
+    const changed = result.matched.filter(m => m.changedColumns.length > 0);
+    expect(changed).toHaveLength(1);
+    expect(changed[0].changedColumns).toEqual(['role']);
     expect(result.summary.unchanged).toBe(1);
   });
 
@@ -127,7 +130,8 @@ describe('computeRowDiff', () => {
     const left = makeSource([{ id: 1, email: null }]);
     const right = makeSource([{ id: 1, email: null }]);
     const result = computeRowDiff(left, right, defaultOptions(['id']));
-    expect(result.matched).toHaveLength(0);
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0].changedColumns).toHaveLength(0);
     expect(result.summary.unchanged).toBe(1);
   });
 
@@ -136,7 +140,8 @@ describe('computeRowDiff', () => {
     const right = makeSource([{ id: 1, count: '42' }]);
     const result = computeRowDiff(left, right, defaultOptions(['id']));
     expect(result.summary.unchanged).toBe(1);
-    expect(result.matched).toHaveLength(0);
+    expect(result.matched).toHaveLength(1);
+    expect(result.matched[0].changedColumns).toHaveLength(0);
   });
 
   it('empty tables produce zero diffs', () => {
@@ -212,7 +217,10 @@ describe('computeRowDiff', () => {
     expect(result.summary.changed).toBe(1);
     expect(result.summary.removed).toBe(1);
     expect(result.summary.added).toBe(1);
-    expect(result.matched[0].changedColumns).toEqual(['score']);
+    // matched[0] = Alice (unchanged), matched[1] = Bob (changed)
+    const changed = result.matched.filter(m => m.changedColumns.length > 0);
+    expect(changed).toHaveLength(1);
+    expect(changed[0].changedColumns).toEqual(['score']);
     expect(result.leftOnly[0].id).toBe(3);
     expect(result.rightOnly[0].id).toBe(4);
   });

--- a/src/test/vscode/extension.vscode.test.ts
+++ b/src/test/vscode/extension.vscode.test.ts
@@ -104,6 +104,8 @@ suite('Extension Activation', () => {
       'viewstor._showExplain',
       'viewstor._openQueryFromMcp',
       'viewstor._openTableDataFromMcp',
+      'viewstor.compareWith',
+      'viewstor.compareData',
     ];
     for (const cmd of required) {
       assert.ok(commands.includes(cmd), `Command ${cmd} not registered`);

--- a/src/webview/scripts/diff-panel.js
+++ b/src/webview/scripts/diff-panel.js
@@ -90,22 +90,27 @@
     var rightHtml = '';
     var columns = rowDiff.allColumns;
 
-    // Changed rows
-    if (activeFilter === 'all' || activeFilter === 'changed') {
-      for (var matchIdx = 0; matchIdx < rowDiff.matched.length; matchIdx++) {
-        var match = rowDiff.matched[matchIdx];
-        leftHtml += '<tr class="diff-changed">';
-        rightHtml += '<tr class="diff-changed">';
-        for (var colIdx = 0; colIdx < columns.length; colIdx++) {
-          var col = columns[colIdx];
-          var isChanged = match.changedColumns.indexOf(col) !== -1;
-          var cellClass = isChanged ? 'diff-cell diff-cell-changed' : 'diff-cell';
-          leftHtml += '<td class="' + cellClass + '">' + formatCell(match.left[col]) + '</td>';
-          rightHtml += '<td class="' + cellClass + '">' + formatCell(match.right[col]) + '</td>';
-        }
-        leftHtml += '</tr>';
-        rightHtml += '</tr>';
+    // Matched rows (changed + unchanged)
+    for (var matchIdx = 0; matchIdx < rowDiff.matched.length; matchIdx++) {
+      var match = rowDiff.matched[matchIdx];
+      var isUnchanged = match.changedColumns.length === 0;
+      var rowCategory = isUnchanged ? 'unchanged' : 'changed';
+
+      // Apply filter
+      if (activeFilter !== 'all' && activeFilter !== rowCategory) continue;
+
+      var rowClass = isUnchanged ? 'diff-unchanged' : 'diff-changed';
+      leftHtml += '<tr class="' + rowClass + '">';
+      rightHtml += '<tr class="' + rowClass + '">';
+      for (var colIdx = 0; colIdx < columns.length; colIdx++) {
+        var col = columns[colIdx];
+        var isCellChanged = match.changedColumns.indexOf(col) !== -1;
+        var cellClass = isCellChanged ? 'diff-cell diff-cell-changed' : 'diff-cell';
+        leftHtml += '<td class="' + cellClass + '">' + formatCell(match.left[col]) + '</td>';
+        rightHtml += '<td class="' + cellClass + '">' + formatCell(match.right[col]) + '</td>';
       }
+      leftHtml += '</tr>';
+      rightHtml += '</tr>';
     }
 
     // Removed rows (left only)

--- a/src/webview/scripts/diff-panel.js
+++ b/src/webview/scripts/diff-panel.js
@@ -1,0 +1,291 @@
+// Diff panel webview script
+(function () {
+  'use strict';
+
+  const vscode = acquireVsCodeApi();
+  const data = window.diffData;
+  if (!data) return;
+
+  const rowDiff = data.rowDiff;
+  const schemaDiff = data.schemaDiff;
+  const leftLabel = data.leftLabel || 'Left';
+  const rightLabel = data.rightLabel || 'Right';
+  const keyColumns = data.keyColumns || [];
+
+  let activeTab = 'rows';
+  let activeFilter = 'all';
+
+  // ---- Tab switching ----
+  const tabs = document.querySelectorAll('.diff-tab');
+  const panels = document.querySelectorAll('.diff-tab-panel');
+
+  tabs.forEach(function (tab) {
+    tab.addEventListener('click', function () {
+      const target = tab.dataset.tab;
+      tabs.forEach(function (tabEl) { tabEl.classList.toggle('active', tabEl.dataset.tab === target); });
+      panels.forEach(function (panelEl) { panelEl.classList.toggle('active', panelEl.id === 'panel-' + target); });
+      activeTab = target;
+    });
+  });
+
+  // ---- Filter buttons ----
+  const filterBtns = document.querySelectorAll('.diff-filter-btn');
+  filterBtns.forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      activeFilter = btn.dataset.filter;
+      filterBtns.forEach(function (filterBtnEl) { filterBtnEl.classList.toggle('active', filterBtnEl.dataset.filter === activeFilter); });
+      renderRowDiff();
+    });
+  });
+
+  // ---- Export buttons ----
+  var exportCsvBtn = document.getElementById('exportCsv');
+  var exportJsonBtn = document.getElementById('exportJson');
+  if (exportCsvBtn) {
+    exportCsvBtn.addEventListener('click', function () {
+      vscode.postMessage({ type: 'exportDiff', format: 'csv' });
+    });
+  }
+  if (exportJsonBtn) {
+    exportJsonBtn.addEventListener('click', function () {
+      vscode.postMessage({ type: 'exportDiff', format: 'json' });
+    });
+  }
+
+  // ---- Swap sides ----
+  var swapBtn = document.getElementById('swapSides');
+  if (swapBtn) {
+    swapBtn.addEventListener('click', function () {
+      vscode.postMessage({ type: 'swapSides' });
+    });
+  }
+
+  // ---- Helpers ----
+  function escapeHtml(str) {
+    if (str === null || str === undefined) return '';
+    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  function formatCell(value) {
+    if (value === null || value === undefined) {
+      return '<span class="diff-cell-empty">NULL</span>';
+    }
+    if (typeof value === 'object') {
+      return escapeHtml(JSON.stringify(value));
+    }
+    return escapeHtml(String(value));
+  }
+
+  function isKeyColumn(colName) {
+    return keyColumns.indexOf(colName) !== -1;
+  }
+
+  // ---- Render row diff ----
+  function renderRowDiff() {
+    var leftBody = document.getElementById('leftTableBody');
+    var rightBody = document.getElementById('rightTableBody');
+    if (!leftBody || !rightBody || !rowDiff) return;
+
+    var leftHtml = '';
+    var rightHtml = '';
+    var columns = rowDiff.allColumns;
+
+    // Changed rows
+    if (activeFilter === 'all' || activeFilter === 'changed') {
+      for (var matchIdx = 0; matchIdx < rowDiff.matched.length; matchIdx++) {
+        var match = rowDiff.matched[matchIdx];
+        leftHtml += '<tr class="diff-changed">';
+        rightHtml += '<tr class="diff-changed">';
+        for (var colIdx = 0; colIdx < columns.length; colIdx++) {
+          var col = columns[colIdx];
+          var isChanged = match.changedColumns.indexOf(col) !== -1;
+          var cellClass = isChanged ? 'diff-cell diff-cell-changed' : 'diff-cell';
+          leftHtml += '<td class="' + cellClass + '">' + formatCell(match.left[col]) + '</td>';
+          rightHtml += '<td class="' + cellClass + '">' + formatCell(match.right[col]) + '</td>';
+        }
+        leftHtml += '</tr>';
+        rightHtml += '</tr>';
+      }
+    }
+
+    // Removed rows (left only)
+    if (activeFilter === 'all' || activeFilter === 'removed') {
+      for (var removedIdx = 0; removedIdx < rowDiff.leftOnly.length; removedIdx++) {
+        var removedRow = rowDiff.leftOnly[removedIdx];
+        leftHtml += '<tr class="diff-removed">';
+        rightHtml += '<tr class="diff-removed">';
+        for (var removedColIdx = 0; removedColIdx < columns.length; removedColIdx++) {
+          var removedCol = columns[removedColIdx];
+          leftHtml += '<td class="diff-cell">' + formatCell(removedRow[removedCol]) + '</td>';
+          rightHtml += '<td class="diff-cell diff-cell-empty"></td>';
+        }
+        leftHtml += '</tr>';
+        rightHtml += '</tr>';
+      }
+    }
+
+    // Added rows (right only)
+    if (activeFilter === 'all' || activeFilter === 'added') {
+      for (var addedIdx = 0; addedIdx < rowDiff.rightOnly.length; addedIdx++) {
+        var addedRow = rowDiff.rightOnly[addedIdx];
+        leftHtml += '<tr class="diff-added">';
+        rightHtml += '<tr class="diff-added">';
+        for (var addedColIdx = 0; addedColIdx < columns.length; addedColIdx++) {
+          var addedCol = columns[addedColIdx];
+          leftHtml += '<td class="diff-cell diff-cell-empty"></td>';
+          rightHtml += '<td class="diff-cell">' + formatCell(addedRow[addedCol]) + '</td>';
+        }
+        leftHtml += '</tr>';
+        rightHtml += '</tr>';
+      }
+    }
+
+    leftBody.innerHTML = leftHtml;
+    rightBody.innerHTML = rightHtml;
+
+    // Synchronized scrolling
+    syncScroll();
+  }
+
+  // ---- Build row diff table headers ----
+  function buildRowHeaders() {
+    var leftHead = document.getElementById('leftTableHead');
+    var rightHead = document.getElementById('rightTableHead');
+    if (!leftHead || !rightHead || !rowDiff) return;
+
+    var columns = rowDiff.allColumns;
+    var headerHtml = '<tr>';
+    for (var headerIdx = 0; headerIdx < columns.length; headerIdx++) {
+      var col = columns[headerIdx];
+      var keyClass = isKeyColumn(col) ? ' class="diff-key-col"' : '';
+      headerHtml += '<th><span' + keyClass + '>' + escapeHtml(col) + '</span></th>';
+    }
+    headerHtml += '</tr>';
+    leftHead.innerHTML = headerHtml;
+    rightHead.innerHTML = headerHtml;
+  }
+
+  // ---- Synchronized scrolling between left and right panes ----
+  function syncScroll() {
+    var leftPane = document.getElementById('leftPane');
+    var rightPane = document.getElementById('rightPane');
+    if (!leftPane || !rightPane) return;
+
+    var syncing = false;
+
+    leftPane.addEventListener('scroll', function () {
+      if (syncing) return;
+      syncing = true;
+      rightPane.scrollTop = leftPane.scrollTop;
+      syncing = false;
+    });
+
+    rightPane.addEventListener('scroll', function () {
+      if (syncing) return;
+      syncing = true;
+      leftPane.scrollTop = rightPane.scrollTop;
+      syncing = false;
+    });
+  }
+
+  // ---- Render schema diff ----
+  function renderSchemaDiff() {
+    var schemaBody = document.getElementById('schemaTableBody');
+    if (!schemaBody) return;
+
+    if (!schemaDiff) {
+      var noSchemaEl = document.querySelector('.diff-no-schema');
+      if (noSchemaEl) noSchemaEl.style.display = 'flex';
+      return;
+    }
+
+    var html = '';
+
+    // Common columns
+    for (var commonIdx = 0; commonIdx < schemaDiff.commonColumns.length; commonIdx++) {
+      var col = schemaDiff.commonColumns[commonIdx];
+      var hasDiff = col.typeDiffers || col.nullableDiffers || col.pkDiffers;
+      var statusParts = [];
+      if (col.typeDiffers) statusParts.push('type');
+      if (col.nullableDiffers) statusParts.push('nullable');
+      if (col.pkDiffers) statusParts.push('pk');
+      var statusText = hasDiff ? statusParts.join(', ') + ' differs' : 'same';
+      var statusClass = hasDiff ? 'diff-status-differs' : 'diff-status-same';
+
+      html += '<tr>';
+      html += '<td>' + escapeHtml(col.name) + '</td>';
+      html += '<td' + (col.typeDiffers ? ' class="diff-cell-changed"' : '') + '>' + escapeHtml(col.leftType) + '</td>';
+      html += '<td' + (col.typeDiffers ? ' class="diff-cell-changed"' : '') + '>' + escapeHtml(col.rightType) + '</td>';
+      html += '<td' + (col.nullableDiffers ? ' class="diff-cell-changed"' : '') + '>' + (col.leftNullable ? 'YES' : 'NO') + '</td>';
+      html += '<td' + (col.nullableDiffers ? ' class="diff-cell-changed"' : '') + '>' + (col.rightNullable ? 'YES' : 'NO') + '</td>';
+      html += '<td' + (col.pkDiffers ? ' class="diff-cell-changed"' : '') + '>' + (col.leftIsPK ? 'YES' : 'NO') + '</td>';
+      html += '<td' + (col.pkDiffers ? ' class="diff-cell-changed"' : '') + '>' + (col.rightIsPK ? 'YES' : 'NO') + '</td>';
+      html += '<td class="' + statusClass + '">' + statusText + '</td>';
+      html += '</tr>';
+    }
+
+    // Left-only columns (removed from right)
+    for (var leftIdx = 0; leftIdx < schemaDiff.leftOnlyColumns.length; leftIdx++) {
+      var leftCol = schemaDiff.leftOnlyColumns[leftIdx];
+      html += '<tr class="diff-removed">';
+      html += '<td>' + escapeHtml(leftCol.name) + '</td>';
+      html += '<td>' + escapeHtml(leftCol.dataType) + '</td>';
+      html += '<td class="diff-cell-empty"></td>';
+      html += '<td>' + (leftCol.nullable ? 'YES' : 'NO') + '</td>';
+      html += '<td class="diff-cell-empty"></td>';
+      html += '<td>' + (leftCol.isPrimaryKey ? 'YES' : 'NO') + '</td>';
+      html += '<td class="diff-cell-empty"></td>';
+      html += '<td class="diff-status-removed">removed</td>';
+      html += '</tr>';
+    }
+
+    // Right-only columns (added)
+    for (var rightIdx = 0; rightIdx < schemaDiff.rightOnlyColumns.length; rightIdx++) {
+      var rightCol = schemaDiff.rightOnlyColumns[rightIdx];
+      html += '<tr class="diff-added">';
+      html += '<td>' + escapeHtml(rightCol.name) + '</td>';
+      html += '<td class="diff-cell-empty"></td>';
+      html += '<td>' + escapeHtml(rightCol.dataType) + '</td>';
+      html += '<td class="diff-cell-empty"></td>';
+      html += '<td>' + (rightCol.nullable ? 'YES' : 'NO') + '</td>';
+      html += '<td class="diff-cell-empty"></td>';
+      html += '<td>' + (rightCol.isPrimaryKey ? 'YES' : 'NO') + '</td>';
+      html += '<td class="diff-status-added">added</td>';
+      html += '</tr>';
+    }
+
+    schemaBody.innerHTML = html;
+  }
+
+  // ---- Handle messages from host ----
+  window.addEventListener('message', function (event) {
+    var msg = event.data;
+    if (!msg) return;
+
+    switch (msg.type) {
+      case 'updateDiff':
+        // Host sent updated diff data after swap or refresh
+        if (msg.rowDiff) {
+          Object.assign(rowDiff, msg.rowDiff);
+          buildRowHeaders();
+          renderRowDiff();
+        }
+        if (msg.schemaDiff) {
+          Object.assign(schemaDiff, msg.schemaDiff);
+          renderSchemaDiff();
+        }
+        if (msg.leftLabel || msg.rightLabel) {
+          var leftHeader = document.getElementById('leftHeader');
+          var rightHeader = document.getElementById('rightHeader');
+          if (leftHeader && msg.leftLabel) leftHeader.textContent = msg.leftLabel;
+          if (rightHeader && msg.rightLabel) rightHeader.textContent = msg.rightLabel;
+        }
+        break;
+    }
+  });
+
+  // ---- Initial render ----
+  buildRowHeaders();
+  renderRowDiff();
+  renderSchemaDiff();
+})();

--- a/src/webview/styles/diff-panel.css
+++ b/src/webview/styles/diff-panel.css
@@ -250,6 +250,10 @@ body {
   font-style: italic;
 }
 
+.diff-cell-empty::after {
+  content: '\00a0';
+}
+
 /* ---- Schema diff table ---- */
 .diff-schema-container {
   flex: 1;

--- a/src/webview/styles/diff-panel.css
+++ b/src/webview/styles/diff-panel.css
@@ -1,0 +1,336 @@
+/* Diff panel webview styles */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--vscode-font-family);
+  font-size: 13px;
+  color: var(--vscode-foreground);
+  background: var(--vscode-editor-background);
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ---- Tab bar ---- */
+.diff-tab-bar {
+  display: flex;
+  align-items: stretch;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  flex-shrink: 0;
+  background: var(--vscode-editorGroupHeader-tabsBackground);
+}
+
+.diff-tab {
+  padding: 8px 20px;
+  font-size: 13px;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  color: var(--vscode-foreground);
+  border-bottom: 2px solid transparent;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+}
+
+.diff-tab:hover {
+  opacity: 1;
+  background: var(--vscode-list-hoverBackground);
+}
+
+.diff-tab.active {
+  opacity: 1;
+  border-bottom-color: var(--vscode-focusBorder);
+  font-weight: 600;
+}
+
+/* ---- Summary bar ---- */
+.diff-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.diff-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.diff-badge.unchanged {
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
+.diff-badge.changed {
+  background: rgba(255, 200, 0, 0.2);
+  color: var(--vscode-foreground);
+}
+
+.diff-badge.added {
+  background: var(--vscode-diffEditor-insertedTextBackground);
+  color: var(--vscode-foreground);
+}
+
+.diff-badge.removed {
+  background: var(--vscode-diffEditor-removedTextBackground);
+  color: var(--vscode-foreground);
+}
+
+.diff-summary-spacer {
+  flex: 1;
+}
+
+.diff-summary button {
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  border: none;
+  padding: 3px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.diff-summary button:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+/* ---- Filter bar ---- */
+.diff-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  flex-shrink: 0;
+}
+
+.diff-filter-btn {
+  padding: 3px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--vscode-foreground);
+  opacity: 0.7;
+}
+
+.diff-filter-btn:hover {
+  opacity: 1;
+  background: var(--vscode-list-hoverBackground);
+}
+
+.diff-filter-btn.active {
+  opacity: 1;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  border-color: var(--vscode-focusBorder);
+}
+
+.diff-filter-label {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  margin-right: 4px;
+}
+
+/* ---- Tab panels ---- */
+.diff-tab-panel {
+  display: none;
+  flex: 1;
+  overflow: hidden;
+  flex-direction: column;
+}
+
+.diff-tab-panel.active {
+  display: flex;
+}
+
+/* ---- Side-by-side row diff ---- */
+.diff-tables-container {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.diff-table-pane {
+  flex: 1;
+  overflow: auto;
+  min-width: 0;
+}
+
+.diff-table-pane:first-child {
+  border-right: 2px solid var(--vscode-panel-border);
+}
+
+.diff-table-pane-header {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--vscode-editorGroupHeader-tabsBackground);
+  border-bottom: 1px solid var(--vscode-panel-border);
+  color: var(--vscode-foreground);
+}
+
+/* ---- Tables ---- */
+.diff-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: auto;
+  font-size: 13px;
+}
+
+.diff-table th {
+  position: sticky;
+  top: 0;
+  background: var(--vscode-editorGroupHeader-tabsBackground);
+  font-weight: 600;
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 2px solid var(--vscode-panel-border);
+  white-space: nowrap;
+  z-index: 2;
+}
+
+.diff-table td {
+  padding: 4px 10px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  white-space: nowrap;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.diff-table tr:hover td {
+  background: var(--vscode-list-hoverBackground);
+}
+
+/* ---- Diff row classes ---- */
+.diff-added {
+  background: var(--vscode-diffEditor-insertedTextBackground);
+}
+
+.diff-removed {
+  background: var(--vscode-diffEditor-removedTextBackground);
+}
+
+.diff-changed {
+  background: rgba(255, 200, 0, 0.08);
+}
+
+.diff-unchanged {
+  opacity: 0.5;
+}
+
+/* ---- Cell-level highlight ---- */
+.diff-cell {
+  /* base cell style */
+}
+
+.diff-cell-changed {
+  background: rgba(255, 200, 0, 0.2);
+  font-weight: 600;
+}
+
+.diff-cell-empty {
+  color: var(--vscode-descriptionForeground);
+  font-style: italic;
+}
+
+/* ---- Schema diff table ---- */
+.diff-schema-container {
+  flex: 1;
+  overflow: auto;
+  padding: 0;
+}
+
+.diff-schema-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: auto;
+  font-size: 13px;
+}
+
+.diff-schema-table th {
+  position: sticky;
+  top: 0;
+  background: var(--vscode-editorGroupHeader-tabsBackground);
+  font-weight: 600;
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 2px solid var(--vscode-panel-border);
+  white-space: nowrap;
+  z-index: 2;
+}
+
+.diff-schema-table td {
+  padding: 4px 10px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  white-space: nowrap;
+}
+
+.diff-schema-table tr:hover td {
+  background: var(--vscode-list-hoverBackground);
+}
+
+.diff-status-same {
+  color: var(--vscode-descriptionForeground);
+}
+
+.diff-status-differs {
+  color: var(--vscode-editorWarning-foreground, #cca700);
+  font-weight: 600;
+}
+
+.diff-status-added {
+  color: var(--vscode-gitDecoration-addedResourceForeground, #81b88b);
+  font-weight: 600;
+}
+
+.diff-status-removed {
+  color: var(--vscode-gitDecoration-deletedResourceForeground, #c74e39);
+  font-weight: 600;
+}
+
+/* ---- Truncation warning ---- */
+.diff-truncated {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--vscode-editorWarning-foreground, #cca700);
+  background: var(--vscode-inputValidation-warningBackground, rgba(200, 160, 0, 0.1));
+  border-bottom: 1px solid var(--vscode-panel-border);
+  flex-shrink: 0;
+}
+
+/* ---- No schema message ---- */
+.diff-no-schema {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  font-size: 14px;
+  color: var(--vscode-descriptionForeground);
+}
+
+/* ---- Key column indicator ---- */
+.diff-key-col {
+  color: var(--vscode-symbolIcon-keyForeground, var(--vscode-foreground));
+}
+
+.diff-key-col::after {
+  content: ' \1F511';
+  font-size: 10px;
+}


### PR DESCRIPTION
## Summary

- **Row diff** — matches rows by PK (auto-detected) or user-specified key columns, highlights added/removed/changed cells side-by-side in a webview panel
- **Schema diff** — compares column names, data types, nullability, and PK status between two tables
- **Cross-connection** — compare tables from different databases/environments (dev vs staging)
- **Export** — diff results as CSV (with `_diff_status` column) or structured JSON
- Right-click table → **Compare With...** or Command Palette → **Viewstor: Compare Data**
- Configurable row limit: `viewstor.diffRowLimit` (default 10,000, max 100,000)

## New files

| File | Purpose |
|------|---------|
| `src/diff/diffTypes.ts` | TypeScript interfaces for diff inputs/outputs |
| `src/diff/diffEngine.ts` | Pure diff computation (row matching, schema comparison, export) |
| `src/diff/diffPanel.ts` | DiffPanelManager — webview panel lifecycle |
| `src/commands/diffCommands.ts` | `compareWith` and `compareData` commands |
| `src/webview/styles/diff-panel.css` | Theme-aware webview CSS |
| `src/webview/scripts/diff-panel.js` | Webview client-side JS |
| `src/test/diffEngine.test.ts` | 33 unit tests for diff engine |

## Test plan

- [x] `npm test` — 722 tests pass (+33 new)
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm run lint` — 0 new errors
- [x] `npm run build` — webpack compiles successfully
- [x] CI pipeline passes
- [x] F5 manual test: right-click table → Compare With → verify webview