### PR TITLE
feat: schema diff with indexes, constraints, triggers, sequences (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Viewstor are documented here. Format based on [Keep a Cha
 
 ### Added
 - **Data diff** — compare data between tables or connections with side-by-side visualization. Row diff matches by PK and highlights added/removed/changed cells; Schema diff compares column types, nullability, and PK status. Export as CSV/JSON. Accessible via right-click "Compare With..." on tables or "Viewstor: Compare Data" command palette ([#5](https://github.com/Siyet/viewstor/issues/5))
+- **Schema diff: indexes, constraints, triggers, sequences** — Schema Diff tab now compares indexes (columns, uniqueness, type), constraints (PK, UNIQUE, FK, CHECK), triggers (timing, events), and sequences (start, increment). Supported for PostgreSQL (full), SQLite (indexes, FK, triggers), and ClickHouse (data skipping indices) ([#66](https://github.com/Siyet/viewstor/issues/66))
 - **Regression prevention** — split monolithic `commands/index.ts` (1598 lines) into 7 focused modules, added 161 tests (ConnectionManager, driver contracts, integration workflows, activation smoke), connectionMap auto-cleanup, getDriverForDatabase concurrency lock, CI changeset size guard ([#59](https://github.com/Siyet/viewstor/issues/59), [#60](https://github.com/Siyet/viewstor/issues/60), [#61](https://github.com/Siyet/viewstor/issues/61))
 
 ## [0.3.2] — 2026-04-13

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ F5 in VS Code → Extension Development Host. Reload Window picks up new `dist/`
 
 Required methods: `connect`, `disconnect`, `ping`, `execute`, `getSchema`, `getTableInfo`, `getTableData`.
 
-Optional: `getTableRowCount`, `getEstimatedRowCount` (pg_class.reltuples / system.tables), `getDDL`, `cancelQuery` (PG: pg_cancel_backend, CH: AbortController), `getCompletions` (structured: table/view/column/schema with parent), `getIndexedColumns` (pg_index query).
+Optional: `getTableRowCount`, `getEstimatedRowCount` (pg_class.reltuples / system.tables), `getDDL`, `cancelQuery` (PG: pg_cancel_backend, CH: AbortController), `getCompletions` (structured: table/view/column/schema with parent), `getIndexedColumns` (pg_index query), `getTableObjects` (indexes, constraints, triggers, sequences — used by data diff).
 
 Drivers: `postgres.ts` (pg), `redis.ts` (ioredis), `clickhouse.ts` (@clickhouse/client), `sqlite.ts` (better-sqlite3).
 
@@ -101,9 +101,9 @@ Multi-source: `ChartDataSource` in config, resolved via `PinnedQueryProvider` (i
 Settings: `viewstor.grafanaUrl`, `viewstor.grafanaApiKey` for direct Grafana push.
 
 ### Data Diff
-`src/diff/diffEngine.ts` — pure functions: `computeRowDiff()` matches rows by key columns (PK or user-specified), compares all non-key columns by stringifying values. `computeSchemaDiff()` compares column names, types, nullability, PK status. `exportDiffAsCsv()` / `exportDiffAsJson()` for diff export. No vscode dependency, fully unit-tested.
+`src/diff/diffEngine.ts` — pure functions: `computeRowDiff()` matches rows by key columns (PK or user-specified), compares all non-key columns by stringifying values. `computeSchemaDiff()` compares column names, types, nullability, PK status. `computeObjectsDiff()` compares indexes, constraints, triggers, sequences. `exportDiffAsCsv()` / `exportDiffAsJson()` for diff export. No vscode dependency, fully unit-tested.
 
-`src/diff/diffTypes.ts` — `DiffSource`, `DiffOptions`, `RowDiffResult`, `MatchedRow`, `SchemaDiffResult`, `ColumnCompare`.
+`src/diff/diffTypes.ts` — `DiffSource`, `DiffOptions`, `RowDiffResult`, `MatchedRow`, `SchemaDiffResult`, `ColumnCompare`, `ObjectsDiffResult`, `ObjectDiffItem`.
 
 `src/diff/diffPanel.ts` — `DiffPanelManager`, webview panel for side-by-side diff visualization. Row diff tab (added/removed/changed rows with cell-level highlighting) and Schema diff tab (column comparison). Export as CSV/JSON. Swap sides button.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Compare data between tables — even across different connections (dev vs stagin
 
 - Right-click a table → **Compare With...** → pick another table from any connected database
 - **Row diff** — matches rows by primary key, highlights added/removed/changed cells side-by-side
-- **Schema diff** — compare column names, types, nullability, and PK status
+- **Schema diff** — compare column names, types, nullability, PK status, plus indexes, constraints, triggers, and sequences
 - Export diff as CSV or JSON
 - Configure max rows in settings (`viewstor.diffRowLimit`, default 10,000)
 

--- a/src/commands/diffCommands.ts
+++ b/src/commands/diffCommands.ts
@@ -87,6 +87,11 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
             rightDriver.getTableData(picked.tableName, picked.schema, rowLimit, 0),
           ]);
 
+          const [leftObjects, rightObjects] = await Promise.all([
+            leftDriver.getTableObjects ? leftDriver.getTableObjects(item.schemaObject!.name, item.schemaObject!.schema) : undefined,
+            rightDriver.getTableObjects ? rightDriver.getTableObjects(picked.tableName, picked.schema) : undefined,
+          ]);
+
           // Auto-detect key columns from left table PKs
           const pkColumns = leftInfo.columns.filter(c => c.isPrimaryKey).map(c => c.name);
           let keyColumns = pkColumns;
@@ -127,6 +132,8 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
           diffPanelManager.show(leftSource, rightSource, options,
             { columns: leftInfo.columns },
             { columns: rightInfo.columns },
+            leftObjects,
+            rightObjects,
           );
         },
       );
@@ -215,6 +222,11 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
             rightDriver.getTableData(rightPick.tableName, rightPick.schema, rowLimit, 0),
           ]);
 
+          const [leftObjects, rightObjects] = await Promise.all([
+            leftDriver.getTableObjects ? leftDriver.getTableObjects(leftPick.tableName, leftPick.schema) : undefined,
+            rightDriver.getTableObjects ? rightDriver.getTableObjects(rightPick.tableName, rightPick.schema) : undefined,
+          ]);
+
           const pkColumns = leftInfo.columns.filter(c => c.isPrimaryKey).map(c => c.name);
           let keyColumns = pkColumns;
 
@@ -251,6 +263,8 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
           diffPanelManager.show(leftSource, rightSource, { keyColumns, rowLimit },
             { columns: leftInfo.columns },
             { columns: rightInfo.columns },
+            leftObjects,
+            rightObjects,
           );
         },
       );

--- a/src/commands/diffCommands.ts
+++ b/src/commands/diffCommands.ts
@@ -45,10 +45,14 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
             rightDriver.getTableData(picked.tableName, picked.schema, rowLimit, 0),
           ]);
 
-          const [leftObjects, rightObjects] = await Promise.all([
-            leftDriver.getTableObjects ? leftDriver.getTableObjects(item.schemaObject!.name, item.schemaObject!.schema) : undefined,
-            rightDriver.getTableObjects ? rightDriver.getTableObjects(picked.tableName, picked.schema) : undefined,
-          ]);
+          // Fetch table objects (indexes, constraints, etc.) — non-critical, fallback to undefined
+          let leftObjects, rightObjects;
+          try {
+            [leftObjects, rightObjects] = await Promise.all([
+              leftDriver.getTableObjects ? leftDriver.getTableObjects(item.schemaObject!.name, item.schemaObject!.schema) : undefined,
+              rightDriver.getTableObjects ? rightDriver.getTableObjects(picked.tableName, picked.schema) : undefined,
+            ]);
+          } catch { /* schema objects unavailable — diff will show columns only */ }
 
           // Auto-detect key columns from left table PKs
           const pkColumns = leftInfo.columns.filter(c => c.isPrimaryKey).map(c => c.name);
@@ -138,10 +142,13 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
             rightDriver.getTableData(rightPick.tableName, rightPick.schema, rowLimit, 0),
           ]);
 
-          const [leftObjects, rightObjects] = await Promise.all([
-            leftDriver.getTableObjects ? leftDriver.getTableObjects(leftPick.tableName, leftPick.schema) : undefined,
-            rightDriver.getTableObjects ? rightDriver.getTableObjects(rightPick.tableName, rightPick.schema) : undefined,
-          ]);
+          let leftObjects, rightObjects;
+          try {
+            [leftObjects, rightObjects] = await Promise.all([
+              leftDriver.getTableObjects ? leftDriver.getTableObjects(leftPick.tableName, leftPick.schema) : undefined,
+              rightDriver.getTableObjects ? rightDriver.getTableObjects(rightPick.tableName, rightPick.schema) : undefined,
+            ]);
+          } catch { /* schema objects unavailable — diff will show columns only */ }
 
           const pkColumns = leftInfo.columns.filter(c => c.isPrimaryKey).map(c => c.name);
           let keyColumns = pkColumns;

--- a/src/commands/diffCommands.ts
+++ b/src/commands/diffCommands.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { CommandContext } from './shared';
 import { ConnectionTreeItem } from '../views/connectionTree';
 import { DiffSource, DiffOptions } from '../diff/diffTypes';
+import { dbg } from '../utils/debug';
 
 export function registerDiffCommands(context: vscode.ExtensionContext, ctx: CommandContext) {
   const { connectionManager, diffPanelManager } = ctx;
@@ -9,36 +10,38 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
   context.subscriptions.push(
     // Context menu on table: "Compare with..."
     vscode.commands.registerCommand('viewstor.compareWith', async (item?: ConnectionTreeItem) => {
-      if (!item?.connectionId || !item.schemaObject) return;
-      if (!diffPanelManager) return;
+      dbg('compareWith', 'item:', item?.connectionId, item?.schemaObject?.name);
+      if (!item?.connectionId || !item.schemaObject) { dbg('compareWith', 'no item'); return; }
+      if (!diffPanelManager) { dbg('compareWith', 'no diffPanelManager'); return; }
 
       const leftState = connectionManager.get(item.connectionId);
-      if (!leftState) return;
+      if (!leftState) { dbg('compareWith', 'no leftState'); return; }
 
-      // Show QuickPick immediately with loading spinner, populate items in background
       const picked = await pickTableWithLoading(
         connectionManager,
         vscode.l10n.t('Select table to compare with "{0}"', item.schemaObject.name),
       );
+      dbg('compareWith', 'picked:', picked?.tableName, picked?.connectionId);
       if (!picked) return;
 
-      // Get left table info and data
       const leftDriver = item.databaseName
         ? await connectionManager.getDriverForDatabase(item.connectionId, item.databaseName)
         : connectionManager.getDriver(item.connectionId);
-      if (!leftDriver) return;
+      if (!leftDriver) { dbg('compareWith', 'no leftDriver'); return; }
 
       const rightDriver = picked.databaseName
         ? await connectionManager.getDriverForDatabase(picked.connectionId, picked.databaseName)
         : connectionManager.getDriver(picked.connectionId);
-      if (!rightDriver) return;
+      if (!rightDriver) { dbg('compareWith', 'no rightDriver for', picked.connectionId); return; }
 
       const rowLimit = vscode.workspace.getConfiguration('viewstor').get<number>('diffRowLimit', 10000);
 
       try {
+      dbg('compareWith', 'starting diff, rowLimit:', rowLimit);
       await vscode.window.withProgress(
         { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Comparing data...') },
         async () => {
+          dbg('compareWith', 'fetching table info and data...');
           const [leftInfo, rightInfo, leftData, rightData] = await Promise.all([
             leftDriver.getTableInfo(item.schemaObject!.name, item.schemaObject!.schema),
             rightDriver.getTableInfo(picked.tableName, picked.schema),
@@ -102,6 +105,7 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
       );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        dbg('compareWith', 'ERROR:', message, err instanceof Error ? err.stack : '');
         vscode.window.showErrorMessage(vscode.l10n.t('Compare failed: {0}', message));
       }
     }),

--- a/src/commands/diffCommands.ts
+++ b/src/commands/diffCommands.ts
@@ -35,6 +35,7 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
 
       const rowLimit = vscode.workspace.getConfiguration('viewstor').get<number>('diffRowLimit', 10000);
 
+      try {
       await vscode.window.withProgress(
         { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Comparing data...') },
         async () => {
@@ -99,6 +100,10 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
           );
         },
       );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(vscode.l10n.t('Compare failed: {0}', message));
+      }
     }),
 
     // Command palette: "Compare Data"
@@ -124,6 +129,7 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
 
       const rowLimit = vscode.workspace.getConfiguration('viewstor').get<number>('diffRowLimit', 10000);
 
+      try {
       await vscode.window.withProgress(
         { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Comparing data...') },
         async () => {
@@ -191,6 +197,10 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
           );
         },
       );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(vscode.l10n.t('Compare failed: {0}', message));
+      }
     }),
   );
 }

--- a/src/commands/diffCommands.ts
+++ b/src/commands/diffCommands.ts
@@ -15,53 +15,11 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
       const leftState = connectionManager.get(item.connectionId);
       if (!leftState) return;
 
-      // Build list of all tables across all connected connections (can be slow)
-      const tableItems = await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Loading tables...') },
-        async () => {
-          const items: Array<{
-            label: string;
-            description: string;
-            connectionId: string;
-            tableName: string;
-            schema?: string;
-            databaseName?: string;
-          }> = [];
-          const allConnections = connectionManager.getAll().filter(s => s.connected);
-          for (const conn of allConnections) {
-            const driver = connectionManager.getDriver(conn.config.id);
-            if (!driver) continue;
-            try {
-              const schema = await driver.getSchema();
-              for (const schemaObj of schema) {
-                if (schemaObj.children) {
-                  for (const child of schemaObj.children) {
-                    if (child.type === 'table' || child.type === 'view') {
-                      items.push({
-                        label: child.name,
-                        description: `${schemaObj.name} — ${conn.config.name}`,
-                        connectionId: conn.config.id,
-                        tableName: child.name,
-                        schema: schemaObj.name,
-                      });
-                    }
-                  }
-                }
-              }
-            } catch { /* skip connections with schema fetch errors */ }
-          }
-          return items;
-        },
+      // Show QuickPick immediately with loading spinner, populate items in background
+      const picked = await pickTableWithLoading(
+        connectionManager,
+        vscode.l10n.t('Select table to compare with "{0}"', item.schemaObject.name),
       );
-
-      if (tableItems.length === 0) {
-        vscode.window.showWarningMessage(vscode.l10n.t('No tables available for comparison. Connect to a database first.'));
-        return;
-      }
-
-      const picked = await vscode.window.showQuickPick(tableItems, {
-        placeHolder: vscode.l10n.t('Select table to compare with "{0}"', item.schemaObject.name),
-      });
       if (!picked) return;
 
       // Get left table info and data
@@ -143,63 +101,21 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
     vscode.commands.registerCommand('viewstor.compareData', async () => {
       if (!diffPanelManager) return;
 
-      const allConnections = connectionManager.getAll().filter(s => s.connected);
-      if (allConnections.length === 0) {
+      if (connectionManager.getAll().filter(s => s.connected).length === 0) {
         vscode.window.showWarningMessage(vscode.l10n.t('No connected databases. Connect first.'));
         return;
       }
 
-      // Build list of all tables (can be slow)
-      const tableItems = await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Loading tables...') },
-        async () => {
-          const items: Array<{
-            label: string;
-            description: string;
-            connectionId: string;
-            tableName: string;
-            schema?: string;
-            databaseName?: string;
-          }> = [];
-          for (const conn of allConnections) {
-            const driver = connectionManager.getDriver(conn.config.id);
-            if (!driver) continue;
-            try {
-              const schema = await driver.getSchema();
-              for (const schemaObj of schema) {
-                if (schemaObj.children) {
-                  for (const child of schemaObj.children) {
-                    if (child.type === 'table' || child.type === 'view') {
-                      items.push({
-                        label: child.name,
-                        description: `${schemaObj.name} — ${conn.config.name}`,
-                        connectionId: conn.config.id,
-                        tableName: child.name,
-                        schema: schemaObj.name,
-                      });
-                    }
-                  }
-                }
-              }
-            } catch { /* skip */ }
-          }
-          return items;
-        },
+      const leftPick = await pickTableWithLoading(
+        connectionManager,
+        vscode.l10n.t('Select LEFT table'),
       );
-
-      if (tableItems.length < 2) {
-        vscode.window.showWarningMessage(vscode.l10n.t('Need at least 2 tables for comparison.'));
-        return;
-      }
-
-      const leftPick = await vscode.window.showQuickPick(tableItems, {
-        placeHolder: vscode.l10n.t('Select LEFT table'),
-      });
       if (!leftPick) return;
 
-      const rightPick = await vscode.window.showQuickPick(tableItems, {
-        placeHolder: vscode.l10n.t('Select RIGHT table'),
-      });
+      const rightPick = await pickTableWithLoading(
+        connectionManager,
+        vscode.l10n.t('Select RIGHT table'),
+      );
       if (!rightPick) return;
 
       const rowLimit = vscode.workspace.getConfiguration('viewstor').get<number>('diffRowLimit', 10000);
@@ -270,4 +186,84 @@ export function registerDiffCommands(context: vscode.ExtensionContext, ctx: Comm
       );
     }),
   );
+}
+
+interface TablePickItem {
+  label: string;
+  description: string;
+  connectionId: string;
+  tableName: string;
+  schema?: string;
+  databaseName?: string;
+}
+
+/**
+ * Show a QuickPick with a loading spinner while fetching table list from all connected databases.
+ * The picker appears immediately with "Loading..." and becomes interactive when data arrives.
+ */
+function pickTableWithLoading(
+  connectionManager: import('../connections/connectionManager').ConnectionManager,
+  placeholder: string,
+): Promise<TablePickItem | undefined> {
+  return new Promise(resolve => {
+    const picker = vscode.window.createQuickPick<TablePickItem>();
+    picker.placeholder = placeholder;
+    picker.busy = true;
+    picker.enabled = false;
+    picker.show();
+
+    // Load tables in background
+    loadAllTables(connectionManager).then(items => {
+      if (items.length === 0) {
+        picker.dispose();
+        vscode.window.showWarningMessage(vscode.l10n.t('No tables available for comparison.'));
+        resolve(undefined);
+        return;
+      }
+      picker.items = items;
+      picker.busy = false;
+      picker.enabled = true;
+    });
+
+    picker.onDidAccept(() => {
+      const selected = picker.selectedItems[0];
+      picker.dispose();
+      resolve(selected);
+    });
+
+    picker.onDidHide(() => {
+      picker.dispose();
+      resolve(undefined);
+    });
+  });
+}
+
+async function loadAllTables(
+  connectionManager: import('../connections/connectionManager').ConnectionManager,
+): Promise<TablePickItem[]> {
+  const items: TablePickItem[] = [];
+  const allConnections = connectionManager.getAll().filter(state => state.connected);
+  for (const conn of allConnections) {
+    const driver = connectionManager.getDriver(conn.config.id);
+    if (!driver) continue;
+    try {
+      const schema = await driver.getSchema();
+      for (const schemaObj of schema) {
+        if (schemaObj.children) {
+          for (const child of schemaObj.children) {
+            if (child.type === 'table' || child.type === 'view') {
+              items.push({
+                label: child.name,
+                description: `${schemaObj.name} — ${conn.config.name}`,
+                connectionId: conn.config.id,
+                tableName: child.name,
+                schema: schemaObj.name,
+              });
+            }
+          }
+        }
+      }
+    } catch { /* skip connections with schema fetch errors */ }
+  }
+  return items;
 }

--- a/src/commands/diffCommands.ts
+++ b/src/commands/diffCommands.ts
@@ -233,12 +233,19 @@ function pickTableWithLoading(
     picker.enabled = false;
     picker.show();
 
-    // Load tables in background
+    let resolved = false;
+    const done = (value: TablePickItem | undefined) => {
+      if (resolved) return;
+      resolved = true;
+      picker.dispose();
+      resolve(value);
+    };
+
     loadAllTables(connectionManager).then(items => {
+      if (resolved) return;
       if (items.length === 0) {
-        picker.dispose();
         vscode.window.showWarningMessage(vscode.l10n.t('No tables available for comparison.'));
-        resolve(undefined);
+        done(undefined);
         return;
       }
       picker.items = items;
@@ -247,14 +254,11 @@ function pickTableWithLoading(
     });
 
     picker.onDidAccept(() => {
-      const selected = picker.selectedItems[0];
-      picker.dispose();
-      resolve(selected);
+      done(picker.selectedItems[0]);
     });
 
     picker.onDidHide(() => {
-      picker.dispose();
-      resolve(undefined);
+      done(undefined);
     });
   });
 }

--- a/src/diff/diffEngine.ts
+++ b/src/diff/diffEngine.ts
@@ -1,5 +1,5 @@
-import { ColumnInfo } from '../types/schema';
-import { DiffOptions, DiffSource, MatchedRow, RowDiffResult, SchemaDiffResult, ColumnDiffInfo, ColumnCompare } from './diffTypes';
+import { ColumnInfo, TableObjects, IndexInfo, ConstraintInfo, TriggerInfo, SequenceInfo } from '../types/schema';
+import { DiffOptions, DiffSource, MatchedRow, RowDiffResult, SchemaDiffResult, ColumnDiffInfo, ColumnCompare, ObjectDiffItem, ObjectsDiffResult } from './diffTypes';
 
 /**
  * Stringify a cell value for comparison.
@@ -154,6 +154,202 @@ export function computeSchemaDiff(leftColumns: ColumnInfo[], rightColumns: Colum
   }
 
   return { leftOnlyColumns, rightOnlyColumns, commonColumns };
+}
+
+/**
+ * Compare table objects (indexes, constraints, triggers, sequences) between two tables.
+ */
+export function computeObjectsDiff(
+  leftObjects: TableObjects | undefined,
+  rightObjects: TableObjects | undefined,
+): ObjectsDiffResult {
+  const empty: TableObjects = { indexes: [], constraints: [], triggers: [], sequences: [] };
+  const left = leftObjects || empty;
+  const right = rightObjects || empty;
+
+  return {
+    indexes: diffIndexes(left.indexes, right.indexes),
+    constraints: diffConstraints(left.constraints, right.constraints),
+    triggers: diffTriggers(left.triggers, right.triggers),
+    sequences: diffSequences(left.sequences, right.sequences),
+  };
+}
+
+function diffIndexes(leftIndexes: IndexInfo[], rightIndexes: IndexInfo[]): ObjectDiffItem[] {
+  const leftMap = new Map(leftIndexes.map(idx => [idx.name, idx]));
+  const rightMap = new Map(rightIndexes.map(idx => [idx.name, idx]));
+  const result: ObjectDiffItem[] = [];
+
+  for (const [name, leftIdx] of leftMap) {
+    const rightIdx = rightMap.get(name);
+    if (!rightIdx) {
+      result.push({
+        name,
+        status: 'removed',
+        leftDetail: formatIndex(leftIdx),
+      });
+    } else {
+      const diffs: string[] = [];
+      if (JSON.stringify(leftIdx.columns) !== JSON.stringify(rightIdx.columns)) {
+        diffs.push(`columns: ${leftIdx.columns.join(', ')} → ${rightIdx.columns.join(', ')}`);
+      }
+      if (leftIdx.unique !== rightIdx.unique) {
+        diffs.push(`unique: ${leftIdx.unique} → ${rightIdx.unique}`);
+      }
+      if ((leftIdx.type || '') !== (rightIdx.type || '')) {
+        diffs.push(`type: ${leftIdx.type || '?'} → ${rightIdx.type || '?'}`);
+      }
+      result.push({
+        name,
+        status: diffs.length > 0 ? 'differs' : 'same',
+        leftDetail: formatIndex(leftIdx),
+        rightDetail: formatIndex(rightIdx),
+        differences: diffs.length > 0 ? diffs : undefined,
+      });
+    }
+  }
+
+  for (const [name, rightIdx] of rightMap) {
+    if (!leftMap.has(name)) {
+      result.push({
+        name,
+        status: 'added',
+        rightDetail: formatIndex(rightIdx),
+      });
+    }
+  }
+
+  return result;
+}
+
+function formatIndex(idx: IndexInfo): string {
+  const parts = [idx.unique ? 'UNIQUE' : '', idx.type || '', `(${idx.columns.join(', ')})`];
+  if (idx.predicate) parts.push(`WHERE ${idx.predicate}`);
+  return parts.filter(Boolean).join(' ').trim();
+}
+
+function diffConstraints(leftConstraints: ConstraintInfo[], rightConstraints: ConstraintInfo[]): ObjectDiffItem[] {
+  const leftMap = new Map(leftConstraints.map(constraint => [constraint.name, constraint]));
+  const rightMap = new Map(rightConstraints.map(constraint => [constraint.name, constraint]));
+  const result: ObjectDiffItem[] = [];
+
+  for (const [name, leftCon] of leftMap) {
+    const rightCon = rightMap.get(name);
+    if (!rightCon) {
+      result.push({ name, status: 'removed', leftDetail: formatConstraint(leftCon) });
+    } else {
+      const diffs: string[] = [];
+      if (leftCon.type !== rightCon.type) diffs.push(`type: ${leftCon.type} → ${rightCon.type}`);
+      if (JSON.stringify(leftCon.columns) !== JSON.stringify(rightCon.columns)) {
+        diffs.push(`columns: ${leftCon.columns.join(', ')} → ${rightCon.columns.join(', ')}`);
+      }
+      if (leftCon.referencedTable !== rightCon.referencedTable) {
+        diffs.push(`references: ${leftCon.referencedTable || '—'} → ${rightCon.referencedTable || '—'}`);
+      }
+      if (leftCon.checkExpression !== rightCon.checkExpression) {
+        diffs.push(`check: ${leftCon.checkExpression || '—'} → ${rightCon.checkExpression || '—'}`);
+      }
+      result.push({
+        name,
+        status: diffs.length > 0 ? 'differs' : 'same',
+        leftDetail: formatConstraint(leftCon),
+        rightDetail: formatConstraint(rightCon),
+        differences: diffs.length > 0 ? diffs : undefined,
+      });
+    }
+  }
+
+  for (const [name, rightCon] of rightMap) {
+    if (!leftMap.has(name)) {
+      result.push({ name, status: 'added', rightDetail: formatConstraint(rightCon) });
+    }
+  }
+
+  return result;
+}
+
+function formatConstraint(constraint: ConstraintInfo): string {
+  let detail = `${constraint.type} (${constraint.columns.join(', ')})`;
+  if (constraint.referencedTable) detail += ` → ${constraint.referencedTable}`;
+  if (constraint.checkExpression) detail += ` ${constraint.checkExpression}`;
+  return detail;
+}
+
+function diffTriggers(leftTriggers: TriggerInfo[], rightTriggers: TriggerInfo[]): ObjectDiffItem[] {
+  const leftMap = new Map(leftTriggers.map(trigger => [trigger.name, trigger]));
+  const rightMap = new Map(rightTriggers.map(trigger => [trigger.name, trigger]));
+  const result: ObjectDiffItem[] = [];
+
+  for (const [name, leftTrig] of leftMap) {
+    const rightTrig = rightMap.get(name);
+    if (!rightTrig) {
+      result.push({ name, status: 'removed', leftDetail: formatTrigger(leftTrig) });
+    } else {
+      const diffs: string[] = [];
+      if (leftTrig.timing !== rightTrig.timing) diffs.push(`timing: ${leftTrig.timing} → ${rightTrig.timing}`);
+      if (leftTrig.events !== rightTrig.events) diffs.push(`events: ${leftTrig.events} → ${rightTrig.events}`);
+      if ((leftTrig.definition || '') !== (rightTrig.definition || '')) diffs.push('definition differs');
+      result.push({
+        name,
+        status: diffs.length > 0 ? 'differs' : 'same',
+        leftDetail: formatTrigger(leftTrig),
+        rightDetail: formatTrigger(rightTrig),
+        differences: diffs.length > 0 ? diffs : undefined,
+      });
+    }
+  }
+
+  for (const [name, rightTrig] of rightMap) {
+    if (!leftMap.has(name)) {
+      result.push({ name, status: 'added', rightDetail: formatTrigger(rightTrig) });
+    }
+  }
+
+  return result;
+}
+
+function formatTrigger(trigger: TriggerInfo): string {
+  return `${trigger.timing} ${trigger.events}${trigger.definition ? ` → ${trigger.definition}` : ''}`;
+}
+
+function diffSequences(leftSequences: SequenceInfo[], rightSequences: SequenceInfo[]): ObjectDiffItem[] {
+  const leftMap = new Map(leftSequences.map(seq => [seq.name, seq]));
+  const rightMap = new Map(rightSequences.map(seq => [seq.name, seq]));
+  const result: ObjectDiffItem[] = [];
+
+  for (const [name, leftSeq] of leftMap) {
+    const rightSeq = rightMap.get(name);
+    if (!rightSeq) {
+      result.push({ name, status: 'removed', leftDetail: formatSequence(leftSeq) });
+    } else {
+      const diffs: string[] = [];
+      if (leftSeq.increment !== rightSeq.increment) diffs.push(`increment: ${leftSeq.increment} → ${rightSeq.increment}`);
+      if (leftSeq.startValue !== rightSeq.startValue) diffs.push(`start: ${leftSeq.startValue} → ${rightSeq.startValue}`);
+      result.push({
+        name,
+        status: diffs.length > 0 ? 'differs' : 'same',
+        leftDetail: formatSequence(leftSeq),
+        rightDetail: formatSequence(rightSeq),
+        differences: diffs.length > 0 ? diffs : undefined,
+      });
+    }
+  }
+
+  for (const [name, rightSeq] of rightMap) {
+    if (!leftMap.has(name)) {
+      result.push({ name, status: 'added', rightDetail: formatSequence(rightSeq) });
+    }
+  }
+
+  return result;
+}
+
+function formatSequence(seq: SequenceInfo): string {
+  const parts: string[] = [];
+  if (seq.dataType) parts.push(seq.dataType);
+  if (seq.startValue !== undefined) parts.push(`start=${seq.startValue}`);
+  if (seq.increment !== undefined) parts.push(`inc=${seq.increment}`);
+  return parts.join(', ') || seq.name;
 }
 
 /**

--- a/src/diff/diffEngine.ts
+++ b/src/diff/diffEngine.ts
@@ -199,6 +199,9 @@ function diffIndexes(leftIndexes: IndexInfo[], rightIndexes: IndexInfo[]): Objec
       if ((leftIdx.type || '') !== (rightIdx.type || '')) {
         diffs.push(`type: ${leftIdx.type || '?'} → ${rightIdx.type || '?'}`);
       }
+      if ((leftIdx.predicate || '') !== (rightIdx.predicate || '')) {
+        diffs.push(`predicate: ${leftIdx.predicate || '—'} → ${rightIdx.predicate || '—'}`);
+      }
       result.push({
         name,
         status: diffs.length > 0 ? 'differs' : 'same',
@@ -248,6 +251,12 @@ function diffConstraints(leftConstraints: ConstraintInfo[], rightConstraints: Co
       }
       if (leftCon.checkExpression !== rightCon.checkExpression) {
         diffs.push(`check: ${leftCon.checkExpression || '—'} → ${rightCon.checkExpression || '—'}`);
+      }
+      if ((leftCon.onDelete || '') !== (rightCon.onDelete || '')) {
+        diffs.push(`onDelete: ${leftCon.onDelete || '—'} → ${rightCon.onDelete || '—'}`);
+      }
+      if ((leftCon.onUpdate || '') !== (rightCon.onUpdate || '')) {
+        diffs.push(`onUpdate: ${leftCon.onUpdate || '—'} → ${rightCon.onUpdate || '—'}`);
       }
       result.push({
         name,

--- a/src/diff/diffPanel.ts
+++ b/src/diff/diffPanel.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { DiffSource, DiffOptions, RowDiffResult, SchemaDiffResult } from './diffTypes';
-import { computeRowDiff, computeSchemaDiff, exportDiffAsCsv, exportDiffAsJson } from './diffEngine';
-import { ColumnInfo } from '../types/schema';
+import { DiffSource, DiffOptions, RowDiffResult, SchemaDiffResult, ObjectsDiffResult } from './diffTypes';
+import { computeRowDiff, computeSchemaDiff, computeObjectsDiff, exportDiffAsCsv, exportDiffAsJson } from './diffEngine';
+import { ColumnInfo, TableObjects } from '../types/schema';
 
 interface DiffState {
   panel: vscode.WebviewPanel;
@@ -11,8 +11,11 @@ interface DiffState {
   options: DiffOptions;
   rowDiff: RowDiffResult;
   schemaDiff: SchemaDiffResult | null;
+  objectsDiff: ObjectsDiffResult | null;
   leftTableInfo?: { columns: ColumnInfo[] };
   rightTableInfo?: { columns: ColumnInfo[] };
+  leftObjects?: TableObjects;
+  rightObjects?: TableObjects;
   disposable: vscode.Disposable;
 }
 
@@ -27,10 +30,15 @@ export class DiffPanelManager {
     options: DiffOptions,
     leftTableInfo?: { columns: ColumnInfo[] },
     rightTableInfo?: { columns: ColumnInfo[] },
+    leftObjects?: TableObjects,
+    rightObjects?: TableObjects,
   ) {
     const rowDiff = computeRowDiff(left, right, options);
     const schemaDiff = leftTableInfo && rightTableInfo
       ? computeSchemaDiff(leftTableInfo.columns, rightTableInfo.columns)
+      : null;
+    const objectsDiff = (leftObjects || rightObjects)
+      ? computeObjectsDiff(leftObjects, rightObjects)
       : null;
 
     const panelTitle = `Diff \u2014 ${left.label} \u2194 ${right.label}`;
@@ -44,8 +52,11 @@ export class DiffPanelManager {
       state.options = options;
       state.rowDiff = rowDiff;
       state.schemaDiff = schemaDiff;
+      state.objectsDiff = objectsDiff;
       state.leftTableInfo = leftTableInfo;
       state.rightTableInfo = rightTableInfo;
+      state.leftObjects = leftObjects;
+      state.rightObjects = rightObjects;
     } else {
       const panel = vscode.window.createWebviewPanel(
         'viewstor.diff',
@@ -70,8 +81,11 @@ export class DiffPanelManager {
         options,
         rowDiff,
         schemaDiff,
+        objectsDiff,
         leftTableInfo,
         rightTableInfo,
+        leftObjects,
+        rightObjects,
         disposable: new vscode.Disposable(() => {}),
       };
       this.diffs.set(panelKey, state);
@@ -112,7 +126,9 @@ export class DiffPanelManager {
           const swappedRight = state.left;
           const swappedLeftInfo = state.rightTableInfo;
           const swappedRightInfo = state.leftTableInfo;
-          this.show(swappedLeft, swappedRight, state.options, swappedLeftInfo, swappedRightInfo);
+          const swappedLeftObjects = state.rightObjects;
+          const swappedRightObjects = state.leftObjects;
+          this.show(swappedLeft, swappedRight, state.options, swappedLeftInfo, swappedRightInfo, swappedLeftObjects, swappedRightObjects);
           break;
         }
       }
@@ -128,6 +144,7 @@ export class DiffPanelManager {
     const diffData = {
       rowDiff: state.rowDiff,
       schemaDiff: state.schemaDiff,
+      objectsDiff: state.objectsDiff,
       leftLabel: state.left.label,
       rightLabel: state.right.label,
       keyColumns: state.options.keyColumns,
@@ -209,6 +226,7 @@ export class DiffPanelManager {
       </table>
     </div>
     ` : '<div class="diff-no-schema">Schema diff not available (table info not provided)</div>'}
+    <div id="objectsDiffContainer"></div>
   </div>
 
   <script>window.diffData = ${safeJsonForScript(diffData)};</script>

--- a/src/diff/diffTypes.ts
+++ b/src/diff/diffTypes.ts
@@ -62,3 +62,20 @@ export interface ColumnCompare {
   rightIsPK: boolean;
   pkDiffers: boolean;
 }
+
+// --- Schema objects diff (indexes, constraints, triggers, sequences) ---
+
+export interface ObjectDiffItem {
+  name: string;
+  status: 'same' | 'differs' | 'added' | 'removed';
+  leftDetail?: string;
+  rightDetail?: string;
+  differences?: string[];
+}
+
+export interface ObjectsDiffResult {
+  indexes: ObjectDiffItem[];
+  constraints: ObjectDiffItem[];
+  triggers: ObjectDiffItem[];
+  sequences: ObjectDiffItem[];
+}

--- a/src/drivers/clickhouse.ts
+++ b/src/drivers/clickhouse.ts
@@ -2,7 +2,7 @@ import { createClient, type ClickHouseClient } from '@clickhouse/client';
 import { DatabaseDriver, CompletionItem } from '../types/driver';
 import { ConnectionConfig } from '../types/connection';
 import { QueryResult, QueryColumn, SortColumn, MAX_RESULT_ROWS } from '../types/query';
-import { SchemaObject, TableInfo, ColumnInfo } from '../types/schema';
+import { SchemaObject, TableInfo, ColumnInfo, TableObjects, IndexInfo } from '../types/schema';
 import { quoteIdentifier } from '../utils/queryHelpers';
 
 export class ClickHouseDriver implements DatabaseDriver {
@@ -230,6 +230,28 @@ export class ClickHouseDriver implements DatabaseDriver {
     const result = await this.execute(sql);
     result.query = sql;
     return result;
+  }
+
+  async getTableObjects(name: string, schema?: string): Promise<TableObjects> {
+    const db = schema || this.database || 'default';
+
+    // Data skipping indices
+    const result = await this.client!.query({
+      query: 'SELECT name, expr, type FROM system.data_skipping_indices WHERE database = {db:String} AND table = {name:String}',
+      format: 'JSONEachRow',
+      query_params: { db, name },
+    });
+    const rawIndexes = await result.json<{ name: string; expr: string; type: string }[]>();
+
+    const indexes: IndexInfo[] = rawIndexes.map(row => ({
+      name: row.name,
+      columns: [row.expr],
+      unique: false,
+      type: row.type,
+    }));
+
+    // ClickHouse has no constraints, triggers, or sequences
+    return { indexes, constraints: [], triggers: [], sequences: [] };
   }
 
   async getCompletions(): Promise<CompletionItem[]> {

--- a/src/drivers/postgres.ts
+++ b/src/drivers/postgres.ts
@@ -3,7 +3,7 @@ import { DatabaseDriver } from '../types/driver';
 import { ConnectionConfig } from '../types/connection';
 import { QueryResult, QueryColumn, SortColumn, MAX_RESULT_ROWS } from '../types/query';
 import { CompletionItem } from '../types/driver';
-import { SchemaObject, TableInfo, ColumnInfo } from '../types/schema';
+import { SchemaObject, TableInfo, ColumnInfo, TableObjects, IndexInfo, ConstraintInfo, TriggerInfo, SequenceInfo } from '../types/schema';
 import { createSSHTunnel, createSocks5Connection, TunnelInfo } from '../connections/tunnel';
 import { quoteIdentifier } from '../utils/queryHelpers';
 
@@ -569,6 +569,126 @@ export class PostgresDriver implements DatabaseDriver {
       WHERE n.nspname = $1 AND c.relname = $2
     `, [schema, name]);
     return new Set(res.rows.map((r: { attname: string }) => r.attname));
+  }
+
+  async getTableObjects(name: string, schema = 'public'): Promise<TableObjects> {
+    // Indexes (excluding primary key indexes)
+    const indexesRes = await this.client!.query(`
+      SELECT i.relname AS index_name,
+             array_agg(a.attname ORDER BY k.ordinality) AS columns,
+             ix.indisunique AS is_unique,
+             am.amname AS index_type,
+             pg_get_expr(ix.indpred, ix.indrelid) AS predicate
+      FROM pg_index ix
+      JOIN pg_class i ON i.oid = ix.indexrelid
+      JOIN pg_class t ON t.oid = ix.indrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
+      JOIN pg_am am ON am.oid = i.relam
+      CROSS JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ordinality)
+      JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+      WHERE n.nspname = $1 AND t.relname = $2
+        AND NOT ix.indisprimary
+      GROUP BY i.relname, ix.indisunique, am.amname, ix.indpred, ix.indrelid
+      ORDER BY i.relname
+    `, [schema, name]);
+
+    const indexes: IndexInfo[] = indexesRes.rows.map((row: any) => ({
+      name: row.index_name,
+      columns: row.columns,
+      unique: row.is_unique,
+      type: row.index_type,
+      predicate: row.predicate ?? undefined,
+    }));
+
+    // Constraints
+    const constraintsRes = await this.client!.query(`
+      SELECT tc.constraint_name, tc.constraint_type,
+             array_agg(DISTINCT kcu.column_name ORDER BY kcu.column_name) AS columns,
+             ccu.table_schema || '.' || ccu.table_name AS ref_table,
+             array_agg(DISTINCT ccu.column_name ORDER BY ccu.column_name) AS ref_columns,
+             rc.delete_rule, rc.update_rule,
+             cc.check_clause
+      FROM information_schema.table_constraints tc
+      LEFT JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+      LEFT JOIN information_schema.constraint_column_usage ccu
+        ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
+        AND tc.constraint_type = 'FOREIGN KEY'
+      LEFT JOIN information_schema.referential_constraints rc
+        ON tc.constraint_name = rc.constraint_name AND tc.table_schema = rc.constraint_schema
+      LEFT JOIN information_schema.check_constraints cc
+        ON tc.constraint_name = cc.constraint_name AND tc.constraint_schema = cc.constraint_schema
+      WHERE tc.table_schema = $1 AND tc.table_name = $2
+        AND tc.constraint_name NOT LIKE '%_not_null'
+      GROUP BY tc.constraint_name, tc.constraint_type, ccu.table_schema, ccu.table_name,
+               rc.delete_rule, rc.update_rule, cc.check_clause
+      ORDER BY tc.constraint_type, tc.constraint_name
+    `, [schema, name]);
+
+    const constraints: ConstraintInfo[] = constraintsRes.rows.map((row: any) => ({
+      name: row.constraint_name,
+      type: row.constraint_type as ConstraintInfo['type'],
+      columns: row.columns?.filter((col: string | null) => col !== null) ?? [],
+      referencedTable: row.constraint_type === 'FOREIGN KEY' ? row.ref_table : undefined,
+      referencedColumns: row.constraint_type === 'FOREIGN KEY'
+        ? row.ref_columns?.filter((col: string | null) => col !== null) : undefined,
+      onDelete: row.delete_rule ?? undefined,
+      onUpdate: row.update_rule ?? undefined,
+      checkExpression: row.check_clause ?? undefined,
+    }));
+
+    // Triggers
+    const triggersRes = await this.client!.query(`
+      SELECT t.tgname AS trigger_name,
+             CASE WHEN t.tgtype & 2 = 2 THEN 'BEFORE'
+                  WHEN t.tgtype & 64 = 64 THEN 'INSTEAD OF'
+                  ELSE 'AFTER' END AS timing,
+             concat_ws(', ',
+               CASE WHEN t.tgtype & 4 = 4 THEN 'INSERT' END,
+               CASE WHEN t.tgtype & 8 = 8 THEN 'DELETE' END,
+               CASE WHEN t.tgtype & 16 = 16 THEN 'UPDATE' END
+             ) AS events,
+             p.proname AS function_name
+      FROM pg_trigger t
+      JOIN pg_class c ON t.tgrelid = c.oid
+      JOIN pg_namespace n ON c.relnamespace = n.oid
+      JOIN pg_proc p ON t.tgfoid = p.oid
+      WHERE n.nspname = $1 AND c.relname = $2
+        AND NOT t.tgisinternal
+      ORDER BY t.tgname
+    `, [schema, name]);
+
+    const triggers: TriggerInfo[] = triggersRes.rows.map((row: any) => ({
+      name: row.trigger_name,
+      timing: row.timing,
+      events: row.events,
+      definition: row.function_name,
+    }));
+
+    // Sequences owned by this table
+    const sequencesRes = await this.client!.query(`
+      SELECT s.relname AS seq_name, sq.data_type,
+             sq.start_value::bigint, sq.increment_by::bigint,
+             sq.min_value::bigint, sq.max_value::bigint
+      FROM pg_class s
+      JOIN pg_depend d ON d.objid = s.oid
+      JOIN pg_class t ON t.oid = d.refobjid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
+      LEFT JOIN pg_sequences sq ON sq.schemaname = n.nspname AND sq.sequencename = s.relname
+      WHERE s.relkind = 'S' AND n.nspname = $1 AND t.relname = $2
+      ORDER BY s.relname
+    `, [schema, name]);
+
+    const sequences: SequenceInfo[] = sequencesRes.rows.map((row: any) => ({
+      name: row.seq_name,
+      dataType: row.data_type ?? undefined,
+      startValue: row.start_value != null ? Number(row.start_value) : undefined,
+      increment: row.increment_by != null ? Number(row.increment_by) : undefined,
+      minValue: row.min_value != null ? Number(row.min_value) : undefined,
+      maxValue: row.max_value != null ? Number(row.max_value) : undefined,
+    }));
+
+    return { indexes, constraints, triggers, sequences };
   }
 
   async getCompletions(): Promise<CompletionItem[]> {

--- a/src/drivers/postgres.ts
+++ b/src/drivers/postgres.ts
@@ -625,13 +625,18 @@ export class PostgresDriver implements DatabaseDriver {
       ORDER BY tc.constraint_type, tc.constraint_name
     `, [schema, name]);
 
+    const toStringArray = (value: unknown): string[] => {
+      if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string');
+      if (typeof value === 'string') return value.replace(/[{}]/g, '').split(',').filter(Boolean);
+      return [];
+    };
     const constraints: ConstraintInfo[] = constraintsRes.rows.map((row: any) => ({
       name: row.constraint_name,
       type: row.constraint_type as ConstraintInfo['type'],
-      columns: row.columns?.filter((col: string | null) => col !== null) ?? [],
+      columns: toStringArray(row.columns),
       referencedTable: row.constraint_type === 'FOREIGN KEY' ? row.ref_table : undefined,
       referencedColumns: row.constraint_type === 'FOREIGN KEY'
-        ? row.ref_columns?.filter((col: string | null) => col !== null) : undefined,
+        ? toStringArray(row.ref_columns) : undefined,
       onDelete: row.delete_rule ?? undefined,
       onUpdate: row.update_rule ?? undefined,
       checkExpression: row.check_clause ?? undefined,

--- a/src/drivers/postgres.ts
+++ b/src/drivers/postgres.ts
@@ -592,9 +592,16 @@ export class PostgresDriver implements DatabaseDriver {
       ORDER BY i.relname
     `, [schema, name]);
 
+    // PG array_agg can return JS array or PG {curly,brace} string depending on driver/query
+    const toStringArray = (value: unknown): string[] => {
+      if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string');
+      if (typeof value === 'string') return value.replace(/[{}]/g, '').split(',').filter(Boolean);
+      return [];
+    };
+
     const indexes: IndexInfo[] = indexesRes.rows.map((row: any) => ({
       name: row.index_name,
-      columns: row.columns,
+      columns: toStringArray(row.columns),
       unique: row.is_unique,
       type: row.index_type,
       predicate: row.predicate ?? undefined,
@@ -625,11 +632,6 @@ export class PostgresDriver implements DatabaseDriver {
       ORDER BY tc.constraint_type, tc.constraint_name
     `, [schema, name]);
 
-    const toStringArray = (value: unknown): string[] => {
-      if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string');
-      if (typeof value === 'string') return value.replace(/[{}]/g, '').split(',').filter(Boolean);
-      return [];
-    };
     const constraints: ConstraintInfo[] = constraintsRes.rows.map((row: any) => ({
       name: row.constraint_name,
       type: row.constraint_type as ConstraintInfo['type'],

--- a/src/drivers/sqlite.ts
+++ b/src/drivers/sqlite.ts
@@ -2,7 +2,7 @@ import type BetterSqlite3 from 'better-sqlite3';
 import { DatabaseDriver, CompletionItem } from '../types/driver';
 import { ConnectionConfig } from '../types/connection';
 import { QueryResult, QueryColumn, SortColumn, MAX_RESULT_ROWS } from '../types/query';
-import { SchemaObject, TableInfo, ColumnInfo } from '../types/schema';
+import { SchemaObject, TableInfo, ColumnInfo, TableObjects, IndexInfo, ConstraintInfo, TriggerInfo } from '../types/schema';
 import { quoteIdentifier } from '../utils/queryHelpers';
 
 // Lazy-load better-sqlite3 to avoid crashing the entire extension on ABI mismatch.
@@ -279,6 +279,88 @@ export class SqliteDriver implements DatabaseDriver {
     }
 
     return items;
+  }
+
+  async getTableObjects(name: string): Promise<TableObjects> {
+    // Indexes
+    const rawIndexes = this.db!.prepare(`PRAGMA index_list(${quoteIdentifier(name)})`).all() as Array<{
+      name: string; unique: number; origin: string;
+    }>;
+    const indexes: IndexInfo[] = [];
+    for (const idx of rawIndexes) {
+      const cols = this.db!.prepare(`PRAGMA index_info(${quoteIdentifier(idx.name)})`).all() as Array<{ name: string }>;
+      indexes.push({
+        name: idx.name,
+        columns: cols.map(col => col.name),
+        unique: idx.unique === 1,
+      });
+    }
+
+    // Constraints: primary key from table_info
+    const constraints: ConstraintInfo[] = [];
+    const pragmaRows = this.db!.prepare(`PRAGMA table_info(${quoteIdentifier(name)})`).all() as Array<{
+      name: string; pk: number;
+    }>;
+    const pkColumns = pragmaRows.filter(row => row.pk > 0).sort((left, right) => left.pk - right.pk);
+    if (pkColumns.length > 0) {
+      constraints.push({
+        name: 'PRIMARY KEY',
+        type: 'PRIMARY KEY',
+        columns: pkColumns.map(row => row.name),
+      });
+    }
+
+    // Constraints: unique indexes (from index_list with origin = 'u')
+    for (const idx of rawIndexes) {
+      if (idx.unique === 1 && idx.origin === 'u') {
+        const cols = this.db!.prepare(`PRAGMA index_info(${quoteIdentifier(idx.name)})`).all() as Array<{ name: string }>;
+        constraints.push({
+          name: idx.name,
+          type: 'UNIQUE',
+          columns: cols.map(col => col.name),
+        });
+      }
+    }
+
+    // Constraints: foreign keys
+    const fks = this.db!.prepare(`PRAGMA foreign_key_list(${quoteIdentifier(name)})`).all() as Array<{
+      id: number; table: string; from: string; to: string; on_delete: string; on_update: string;
+    }>;
+    const fkGroups = new Map<number, typeof fks>();
+    for (const fk of fks) {
+      if (!fkGroups.has(fk.id)) fkGroups.set(fk.id, []);
+      fkGroups.get(fk.id)!.push(fk);
+    }
+    for (const [fkId, group] of fkGroups) {
+      constraints.push({
+        name: `fk_${fkId}`,
+        type: 'FOREIGN KEY',
+        columns: group.map(fk => fk.from),
+        referencedTable: group[0].table,
+        referencedColumns: group.map(fk => fk.to),
+        onDelete: group[0].on_delete !== 'NO ACTION' ? group[0].on_delete : undefined,
+        onUpdate: group[0].on_update !== 'NO ACTION' ? group[0].on_update : undefined,
+      });
+    }
+
+    // Triggers
+    const rawTriggers = this.db!.prepare(
+      'SELECT name, sql FROM sqlite_master WHERE type = \'trigger\' AND tbl_name = ?'
+    ).all(name) as Array<{ name: string; sql: string }>;
+    const triggers: TriggerInfo[] = rawTriggers.map(trigger => {
+      const match = trigger.sql?.match(
+        /CREATE\s+TRIGGER\s+\S+\s+(BEFORE|AFTER|INSTEAD\s+OF)\s+(INSERT|UPDATE|DELETE)/i
+      );
+      return {
+        name: trigger.name,
+        timing: match ? match[1].toUpperCase() : 'UNKNOWN',
+        events: match ? match[2].toUpperCase() : 'UNKNOWN',
+        definition: trigger.sql ?? undefined,
+      };
+    });
+
+    // SQLite has no sequences
+    return { indexes, constraints, triggers, sequences: [] };
   }
 
   // --- Private helpers ---

--- a/src/test/diffEngine.test.ts
+++ b/src/test/diffEngine.test.ts
@@ -388,6 +388,183 @@ describe('computeObjectsDiff', () => {
     expect(result.triggers).toHaveLength(0);
     expect(result.sequences).toHaveLength(0);
   });
+
+  it('index with predicate (partial index): left has predicate, right does not', () => {
+    const left = {
+      indexes: [{ name: 'idx_active', columns: ['email'], unique: false, type: 'btree', predicate: 'active = true' }],
+      constraints: [], triggers: [], sequences: [],
+    };
+    const right = {
+      indexes: [{ name: 'idx_active', columns: ['email'], unique: false, type: 'btree' }],
+      constraints: [], triggers: [], sequences: [],
+    };
+    const result = computeObjectsDiff(left, right);
+    expect(result.indexes).toHaveLength(1);
+    expect(result.indexes[0].status).toBe('differs');
+    expect(result.indexes[0].differences).toBeDefined();
+    expect(result.indexes[0].differences!.some(d => d.includes('predicate'))).toBe(true);
+    // Left detail should include WHERE clause
+    expect(result.indexes[0].leftDetail).toContain('WHERE active = true');
+  });
+
+  it('constraint FK with different ON DELETE actions', () => {
+    const left = {
+      indexes: [], triggers: [], sequences: [],
+      constraints: [{
+        name: 'fk_order_user',
+        type: 'FOREIGN KEY' as const,
+        columns: ['user_id'],
+        referencedTable: 'public.users',
+        onDelete: 'CASCADE',
+      }],
+    };
+    const right = {
+      indexes: [], triggers: [], sequences: [],
+      constraints: [{
+        name: 'fk_order_user',
+        type: 'FOREIGN KEY' as const,
+        columns: ['user_id'],
+        referencedTable: 'public.users',
+        onDelete: 'SET NULL',
+      }],
+    };
+    const result = computeObjectsDiff(left, right);
+    expect(result.constraints).toHaveLength(1);
+    expect(result.constraints[0].status).toBe('differs');
+    expect(result.constraints[0].differences).toBeDefined();
+    expect(result.constraints[0].differences!.some(d => d.includes('onDelete'))).toBe(true);
+    expect(result.constraints[0].differences!.some(d => d.includes('CASCADE') && d.includes('SET NULL'))).toBe(true);
+  });
+
+  it('trigger timing change: BEFORE -> AFTER', () => {
+    const left = {
+      indexes: [], constraints: [], sequences: [],
+      triggers: [{ name: 'trg_audit', timing: 'BEFORE', events: 'INSERT', definition: 'audit_fn()' }],
+    };
+    const right = {
+      indexes: [], constraints: [], sequences: [],
+      triggers: [{ name: 'trg_audit', timing: 'AFTER', events: 'INSERT', definition: 'audit_fn()' }],
+    };
+    const result = computeObjectsDiff(left, right);
+    expect(result.triggers).toHaveLength(1);
+    expect(result.triggers[0].status).toBe('differs');
+    expect(result.triggers[0].differences).toBeDefined();
+    expect(result.triggers[0].differences!.some(d => d.includes('timing'))).toBe(true);
+    expect(result.triggers[0].differences!.some(d => d.includes('BEFORE') && d.includes('AFTER'))).toBe(true);
+  });
+
+  it('mixed: indexes + constraints + triggers all at once', () => {
+    const left = {
+      indexes: [
+        { name: 'idx_a', columns: ['a'], unique: false },
+        { name: 'idx_b', columns: ['b'], unique: true },
+      ],
+      constraints: [
+        { name: 'pk_id', type: 'PRIMARY KEY' as const, columns: ['id'] },
+      ],
+      triggers: [
+        { name: 'trg_log', timing: 'AFTER', events: 'UPDATE', definition: 'log_fn()' },
+      ],
+      sequences: [],
+    };
+    const right = {
+      indexes: [
+        { name: 'idx_a', columns: ['a', 'c'], unique: false }, // changed
+        { name: 'idx_c', columns: ['c'], unique: false },      // added
+      ],
+      constraints: [
+        { name: 'pk_id', type: 'PRIMARY KEY' as const, columns: ['id'] }, // same
+        { name: 'uq_email', type: 'UNIQUE' as const, columns: ['email'] }, // added
+      ],
+      triggers: [], // trg_log removed
+      sequences: [],
+    };
+    const result = computeObjectsDiff(left, right);
+
+    // Indexes: idx_a differs, idx_b removed, idx_c added
+    expect(result.indexes).toHaveLength(3);
+    const idxA = result.indexes.find(i => i.name === 'idx_a');
+    const idxB = result.indexes.find(i => i.name === 'idx_b');
+    const idxC = result.indexes.find(i => i.name === 'idx_c');
+    expect(idxA!.status).toBe('differs');
+    expect(idxB!.status).toBe('removed');
+    expect(idxC!.status).toBe('added');
+
+    // Constraints: pk_id same, uq_email added
+    expect(result.constraints).toHaveLength(2);
+    const pkId = result.constraints.find(c => c.name === 'pk_id');
+    const uqEmail = result.constraints.find(c => c.name === 'uq_email');
+    expect(pkId!.status).toBe('same');
+    expect(uqEmail!.status).toBe('added');
+
+    // Triggers: trg_log removed
+    expect(result.triggers).toHaveLength(1);
+    expect(result.triggers[0].status).toBe('removed');
+    expect(result.triggers[0].name).toBe('trg_log');
+
+    // Sequences: empty on both sides
+    expect(result.sequences).toHaveLength(0);
+  });
+
+  it('large number of indexes: 20 indexes, 2 differ, 3 added, 1 removed', () => {
+    // 17 shared indexes (15 same + 2 differ) + 1 left-only + 3 right-only = 20 left, 20 right
+    const sharedIndexes = Array.from({ length: 15 }, (_, index) => ({
+      name: `idx_shared_${index}`,
+      columns: [`col_${index}`],
+      unique: false,
+      type: 'btree',
+    }));
+
+    const leftOnly = { name: 'idx_removed', columns: ['old_col'], unique: false, type: 'btree' };
+    const differLeft1 = { name: 'idx_diff_1', columns: ['a'], unique: false, type: 'btree' };
+    const differLeft2 = { name: 'idx_diff_2', columns: ['b'], unique: true, type: 'btree' };
+    const differRight1 = { name: 'idx_diff_1', columns: ['a', 'x'], unique: false, type: 'btree' };
+    const differRight2 = { name: 'idx_diff_2', columns: ['b'], unique: false, type: 'btree' }; // unique changed
+
+    const rightAdded = Array.from({ length: 3 }, (_, index) => ({
+      name: `idx_new_${index}`,
+      columns: [`new_col_${index}`],
+      unique: false,
+      type: 'btree',
+    }));
+
+    const left = {
+      indexes: [...sharedIndexes, leftOnly, differLeft1, differLeft2],
+      constraints: [], triggers: [], sequences: [],
+    };
+    const right = {
+      indexes: [...sharedIndexes, differRight1, differRight2, ...rightAdded],
+      constraints: [], triggers: [], sequences: [],
+    };
+
+    const result = computeObjectsDiff(left, right);
+
+    const same = result.indexes.filter(i => i.status === 'same');
+    const differs = result.indexes.filter(i => i.status === 'differs');
+    const added = result.indexes.filter(i => i.status === 'added');
+    const removed = result.indexes.filter(i => i.status === 'removed');
+
+    expect(same).toHaveLength(15);
+    expect(differs).toHaveLength(2);
+    expect(added).toHaveLength(3);
+    expect(removed).toHaveLength(1);
+    expect(result.indexes).toHaveLength(21); // 15 + 2 + 3 + 1
+  });
+
+  it('index with empty string name does not crash', () => {
+    const left = {
+      indexes: [{ name: '', columns: ['a'], unique: false }],
+      constraints: [], triggers: [], sequences: [],
+    };
+    const right = {
+      indexes: [{ name: '', columns: ['a'], unique: false }],
+      constraints: [], triggers: [], sequences: [],
+    };
+    const result = computeObjectsDiff(left, right);
+    expect(result.indexes).toHaveLength(1);
+    expect(result.indexes[0].name).toBe('');
+    expect(result.indexes[0].status).toBe('same');
+  });
 });
 
 // --- exportDiffAsCsv ---

--- a/src/test/diffEngine.test.ts
+++ b/src/test/diffEngine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { stringifyCell, computeRowDiff, computeSchemaDiff, exportDiffAsCsv, exportDiffAsJson } from '../diff/diffEngine';
+import { stringifyCell, computeRowDiff, computeSchemaDiff, computeObjectsDiff, exportDiffAsCsv, exportDiffAsJson } from '../diff/diffEngine';
 import { DiffSource, DiffOptions } from '../diff/diffTypes';
 import { ColumnInfo } from '../types/schema';
 
@@ -291,6 +291,102 @@ describe('computeSchemaDiff', () => {
     expect(result.leftOnlyColumns).toHaveLength(0);
     expect(result.rightOnlyColumns).toHaveLength(0);
     expect(result.commonColumns).toHaveLength(0);
+  });
+});
+
+// --- computeObjectsDiff ---
+
+describe('computeObjectsDiff', () => {
+  it('identical indexes produce same status', () => {
+    const objects = {
+      indexes: [{ name: 'idx_name', columns: ['name'], unique: false, type: 'btree' }],
+      constraints: [], triggers: [], sequences: [],
+    };
+    const result = computeObjectsDiff(objects, objects);
+    expect(result.indexes).toHaveLength(1);
+    expect(result.indexes[0].status).toBe('same');
+  });
+
+  it('detects added index', () => {
+    const left = { indexes: [], constraints: [], triggers: [], sequences: [] };
+    const right = {
+      indexes: [{ name: 'idx_new', columns: ['email'], unique: true, type: 'btree' }],
+      constraints: [], triggers: [], sequences: [],
+    };
+    const result = computeObjectsDiff(left, right);
+    expect(result.indexes).toHaveLength(1);
+    expect(result.indexes[0].status).toBe('added');
+    expect(result.indexes[0].name).toBe('idx_new');
+  });
+
+  it('detects removed index', () => {
+    const left = {
+      indexes: [{ name: 'idx_old', columns: ['name'], unique: false }],
+      constraints: [], triggers: [], sequences: [],
+    };
+    const right = { indexes: [], constraints: [], triggers: [], sequences: [] };
+    const result = computeObjectsDiff(left, right);
+    expect(result.indexes).toHaveLength(1);
+    expect(result.indexes[0].status).toBe('removed');
+  });
+
+  it('detects index column change', () => {
+    const left = {
+      indexes: [{ name: 'idx_x', columns: ['a', 'b'], unique: false }],
+      constraints: [], triggers: [], sequences: [],
+    };
+    const right = {
+      indexes: [{ name: 'idx_x', columns: ['a', 'c'], unique: false }],
+      constraints: [], triggers: [], sequences: [],
+    };
+    const result = computeObjectsDiff(left, right);
+    expect(result.indexes[0].status).toBe('differs');
+    expect(result.indexes[0].differences).toBeDefined();
+  });
+
+  it('detects constraint type change', () => {
+    const left = {
+      indexes: [], triggers: [], sequences: [],
+      constraints: [{ name: 'pk_id', type: 'PRIMARY KEY' as const, columns: ['id'] }],
+    };
+    const right = {
+      indexes: [], triggers: [], sequences: [],
+      constraints: [{ name: 'pk_id', type: 'UNIQUE' as const, columns: ['id'] }],
+    };
+    const result = computeObjectsDiff(left, right);
+    expect(result.constraints[0].status).toBe('differs');
+  });
+
+  it('detects added trigger', () => {
+    const left = { indexes: [], constraints: [], triggers: [], sequences: [] };
+    const right = {
+      indexes: [], constraints: [], sequences: [],
+      triggers: [{ name: 'trg_audit', timing: 'AFTER', events: 'INSERT', definition: 'audit_fn' }],
+    };
+    const result = computeObjectsDiff(left, right);
+    expect(result.triggers).toHaveLength(1);
+    expect(result.triggers[0].status).toBe('added');
+  });
+
+  it('detects sequence increment change', () => {
+    const left = {
+      indexes: [], constraints: [], triggers: [],
+      sequences: [{ name: 'seq_id', startValue: 1, increment: 1 }],
+    };
+    const right = {
+      indexes: [], constraints: [], triggers: [],
+      sequences: [{ name: 'seq_id', startValue: 1, increment: 10 }],
+    };
+    const result = computeObjectsDiff(left, right);
+    expect(result.sequences[0].status).toBe('differs');
+  });
+
+  it('handles undefined inputs gracefully', () => {
+    const result = computeObjectsDiff(undefined, undefined);
+    expect(result.indexes).toHaveLength(0);
+    expect(result.constraints).toHaveLength(0);
+    expect(result.triggers).toHaveLength(0);
+    expect(result.sequences).toHaveLength(0);
   });
 });
 

--- a/src/test/driverContract.test.ts
+++ b/src/test/driverContract.test.ts
@@ -51,6 +51,7 @@ const OPTIONAL_METHODS: (keyof DatabaseDriver)[] = [
   'getIndexedColumns',
   'getTableRowCount',
   'getEstimatedRowCount',
+  'getTableObjects',
 ];
 
 interface DriverSpec {
@@ -73,6 +74,7 @@ const DRIVER_SPECS: DriverSpec[] = [
       'getIndexedColumns',
       'getTableRowCount',
       'getEstimatedRowCount',
+      'getTableObjects',
     ],
   },
   {
@@ -91,6 +93,7 @@ const DRIVER_SPECS: DriverSpec[] = [
       'getCompletions',
       'getTableRowCount',
       'getEstimatedRowCount',
+      'getTableObjects',
     ],
   },
   {
@@ -103,6 +106,7 @@ const DRIVER_SPECS: DriverSpec[] = [
       'getIndexedColumns',
       'getTableRowCount',
       'getEstimatedRowCount',
+      'getTableObjects',
     ],
   },
 ];

--- a/src/test/workflows.test.ts
+++ b/src/test/workflows.test.ts
@@ -118,8 +118,11 @@ import { ConnectionManager } from '../connections/connectionManager';
 import { QueryEditorProvider } from '../editors/queryEditor';
 import { ExportService } from '../services/exportService';
 import { parseDBeaver } from '../services/importService';
+import { computeRowDiff, computeSchemaDiff, computeObjectsDiff, exportDiffAsCsv, exportDiffAsJson } from '../diff/diffEngine';
 import { ConnectionConfig } from '../types/connection';
 import { QueryResult } from '../types/query';
+import { ColumnInfo, TableObjects } from '../types/schema';
+import { DiffSource, DiffOptions } from '../diff/diffTypes';
 import { createDriver } from '../drivers';
 
 // --- Helpers ---
@@ -671,5 +674,158 @@ describe('Workflow 6: DBeaver import -> connection configs round-trip', () => {
     const result = parseDBeaver(dbeaverJson);
     expect(result.connections).toHaveLength(1);
     expect(result.connections[0].readonly).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workflow 7: Diff engine full pipeline
+// ---------------------------------------------------------------------------
+describe('Workflow 7: diff engine full pipeline', () => {
+  function makeDiffSource(rows: Record<string, unknown>[], columns?: string[]): DiffSource {
+    const colNames = columns || (rows.length > 0 ? Object.keys(rows[0]) : []);
+    return {
+      label: 'test',
+      columns: colNames.map(name => ({ name, dataType: 'text' })),
+      rows,
+    };
+  }
+
+  function makeDiffOptions(keyColumns: string[], rowLimit = 10000): DiffOptions {
+    return { keyColumns, rowLimit };
+  }
+
+  it('full pipeline: row diff -> schema diff -> objects diff -> export CSV -> export JSON', () => {
+    // Step 1: Row diff with mixed changes
+    const leftRows = [
+      { id: 1, name: 'Alice', score: 90 },
+      { id: 2, name: 'Bob', score: 80 },
+      { id: 3, name: 'Carol', score: 70 },
+    ];
+    const rightRows = [
+      { id: 1, name: 'Alice', score: 95 },  // changed: score
+      { id: 2, name: 'Bob', score: 80 },    // unchanged
+      { id: 4, name: 'Dave', score: 60 },   // added
+    ];
+
+    const rowDiff = computeRowDiff(
+      makeDiffSource(leftRows),
+      makeDiffSource(rightRows),
+      makeDiffOptions(['id']),
+    );
+
+    expect(rowDiff.summary.changed).toBe(1);
+    expect(rowDiff.summary.unchanged).toBe(1);
+    expect(rowDiff.summary.added).toBe(1);
+    expect(rowDiff.summary.removed).toBe(1);
+    expect(rowDiff.leftOnly).toHaveLength(1);
+    expect(rowDiff.leftOnly[0].id).toBe(3);
+    expect(rowDiff.rightOnly).toHaveLength(1);
+    expect(rowDiff.rightOnly[0].id).toBe(4);
+
+    // Step 2: Schema diff
+    const leftColumns: ColumnInfo[] = [
+      { name: 'id', dataType: 'integer', nullable: false, isPrimaryKey: true },
+      { name: 'name', dataType: 'varchar(100)', nullable: false, isPrimaryKey: false },
+      { name: 'score', dataType: 'integer', nullable: true, isPrimaryKey: false },
+      { name: 'email', dataType: 'text', nullable: true, isPrimaryKey: false },
+    ];
+    const rightColumns: ColumnInfo[] = [
+      { name: 'id', dataType: 'integer', nullable: false, isPrimaryKey: true },
+      { name: 'name', dataType: 'text', nullable: false, isPrimaryKey: false }, // type changed
+      { name: 'score', dataType: 'integer', nullable: false, isPrimaryKey: false }, // nullable changed
+      { name: 'phone', dataType: 'varchar(20)', nullable: true, isPrimaryKey: false }, // new column
+    ];
+
+    const schemaDiff = computeSchemaDiff(leftColumns, rightColumns);
+
+    expect(schemaDiff.leftOnlyColumns).toHaveLength(1);
+    expect(schemaDiff.leftOnlyColumns[0].name).toBe('email');
+    expect(schemaDiff.rightOnlyColumns).toHaveLength(1);
+    expect(schemaDiff.rightOnlyColumns[0].name).toBe('phone');
+    expect(schemaDiff.commonColumns).toHaveLength(3);
+    const nameCol = schemaDiff.commonColumns.find(c => c.name === 'name');
+    expect(nameCol!.typeDiffers).toBe(true);
+    const scoreCol = schemaDiff.commonColumns.find(c => c.name === 'score');
+    expect(scoreCol!.nullableDiffers).toBe(true);
+
+    // Step 3: Objects diff
+    const leftObjects: TableObjects = {
+      indexes: [
+        { name: 'idx_name', columns: ['name'], unique: false, type: 'btree' },
+        { name: 'idx_score', columns: ['score'], unique: false, type: 'btree' },
+      ],
+      constraints: [
+        { name: 'pk_users', type: 'PRIMARY KEY', columns: ['id'] },
+        { name: 'fk_dept', type: 'FOREIGN KEY', columns: ['dept_id'], referencedTable: 'departments', onDelete: 'CASCADE' },
+      ],
+      triggers: [
+        { name: 'trg_updated', timing: 'BEFORE', events: 'UPDATE', definition: 'set_updated_at()' },
+      ],
+      sequences: [
+        { name: 'users_id_seq', startValue: 1, increment: 1 },
+      ],
+    };
+    const rightObjects: TableObjects = {
+      indexes: [
+        { name: 'idx_name', columns: ['name'], unique: true, type: 'btree' },  // unique changed
+        { name: 'idx_phone', columns: ['phone'], unique: false, type: 'btree' }, // added
+      ],
+      constraints: [
+        { name: 'pk_users', type: 'PRIMARY KEY', columns: ['id'] },
+        { name: 'fk_dept', type: 'FOREIGN KEY', columns: ['dept_id'], referencedTable: 'departments', onDelete: 'SET NULL' },
+      ],
+      triggers: [
+        { name: 'trg_updated', timing: 'AFTER', events: 'UPDATE', definition: 'set_updated_at()' }, // timing changed
+      ],
+      sequences: [
+        { name: 'users_id_seq', startValue: 1, increment: 1 }, // same
+      ],
+    };
+
+    const objectsDiff = computeObjectsDiff(leftObjects, rightObjects);
+
+    // idx_name differs (unique changed), idx_score removed, idx_phone added
+    expect(objectsDiff.indexes).toHaveLength(3);
+    expect(objectsDiff.indexes.find(i => i.name === 'idx_name')!.status).toBe('differs');
+    expect(objectsDiff.indexes.find(i => i.name === 'idx_score')!.status).toBe('removed');
+    expect(objectsDiff.indexes.find(i => i.name === 'idx_phone')!.status).toBe('added');
+
+    // pk_users same, fk_dept differs (onDelete)
+    expect(objectsDiff.constraints.find(c => c.name === 'pk_users')!.status).toBe('same');
+    expect(objectsDiff.constraints.find(c => c.name === 'fk_dept')!.status).toBe('differs');
+
+    // trg_updated differs (timing BEFORE -> AFTER)
+    expect(objectsDiff.triggers[0].status).toBe('differs');
+
+    // users_id_seq same
+    expect(objectsDiff.sequences[0].status).toBe('same');
+
+    // Step 4: Export as CSV
+    const csv = exportDiffAsCsv(rowDiff, ['id']);
+    const csvLines = csv.split('\n');
+    expect(csvLines[0]).toBe('_diff_status,id,name,score');
+    expect(csvLines.some(line => line.startsWith('removed'))).toBe(true);
+    expect(csvLines.some(line => line.startsWith('changed'))).toBe(true);
+    expect(csvLines.some(line => line.startsWith('added'))).toBe(true);
+    // Total lines: header + 1 removed + 2 matched + 1 added = 5
+    expect(csvLines).toHaveLength(5);
+
+    // Step 5: Export as JSON
+    const json = exportDiffAsJson(rowDiff);
+    const parsed = JSON.parse(json);
+    expect(parsed.summary).toBeDefined();
+    expect(parsed.summary.changed).toBe(1);
+    expect(parsed.summary.added).toBe(1);
+    expect(parsed.summary.removed).toBe(1);
+    expect(parsed.summary.unchanged).toBe(1);
+    expect(parsed.changed).toHaveLength(2); // matched includes both changed and unchanged
+    expect(parsed.added).toHaveLength(1);
+    expect(parsed.removed).toHaveLength(1);
+    // Verify structure of a changed entry
+    const changedEntry = parsed.changed.find((entry: { changedColumns: string[] }) => entry.changedColumns.length > 0);
+    expect(changedEntry).toBeDefined();
+    expect(changedEntry.changedColumns).toEqual(['score']);
+    expect(changedEntry.left).toBeDefined();
+    expect(changedEntry.right).toBeDefined();
   });
 });

--- a/src/types/driver.ts
+++ b/src/types/driver.ts
@@ -1,6 +1,6 @@
 import { ConnectionConfig } from './connection';
 import { QueryResult, SortColumn } from './query';
-import { SchemaObject, TableInfo } from './schema';
+import { SchemaObject, TableInfo, TableObjects } from './schema';
 
 /**
  * Unified interface that all database drivers must implement.
@@ -21,6 +21,8 @@ export interface DatabaseDriver {
   getCompletions?(): Promise<CompletionItem[]>;
   /** Returns column names that have indexes for a given table */
   getIndexedColumns?(name: string, schema?: string): Promise<Set<string>>;
+  /** Returns indexes, constraints, triggers, sequences for a table */
+  getTableObjects?(name: string, schema?: string): Promise<TableObjects>;
 }
 
 export interface CompletionItem {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -38,3 +38,56 @@ export interface TableInfo {
   rowCount?: number;
   sizeBytes?: number;
 }
+
+export interface IndexInfo {
+  name: string;
+  columns: string[];
+  unique: boolean;
+  /** Index type: btree, hash, gin, gist, etc. */
+  type?: string;
+  /** Partial index WHERE clause */
+  predicate?: string;
+}
+
+export interface ConstraintInfo {
+  name: string;
+  type: 'PRIMARY KEY' | 'UNIQUE' | 'FOREIGN KEY' | 'CHECK';
+  columns: string[];
+  /** FK: referenced table (schema.table) */
+  referencedTable?: string;
+  /** FK: referenced columns */
+  referencedColumns?: string[];
+  /** FK: ON DELETE action */
+  onDelete?: string;
+  /** FK: ON UPDATE action */
+  onUpdate?: string;
+  /** CHECK: expression */
+  checkExpression?: string;
+}
+
+export interface TriggerInfo {
+  name: string;
+  /** BEFORE, AFTER, INSTEAD OF */
+  timing: string;
+  /** INSERT, UPDATE, DELETE (comma-separated if multiple) */
+  events: string;
+  /** Trigger function name (PG) or full SQL (SQLite) */
+  definition?: string;
+}
+
+export interface SequenceInfo {
+  name: string;
+  dataType?: string;
+  startValue?: number;
+  increment?: number;
+  minValue?: number;
+  maxValue?: number;
+}
+
+/** Extended table metadata including related schema objects */
+export interface TableObjects {
+  indexes: IndexInfo[];
+  constraints: ConstraintInfo[];
+  triggers: TriggerInfo[];
+  sequences: SequenceInfo[];
+}

--- a/src/webview/scripts/diff-panel.js
+++ b/src/webview/scripts/diff-panel.js
@@ -8,6 +8,7 @@
 
   const rowDiff = data.rowDiff;
   const schemaDiff = data.schemaDiff;
+  const objectsDiff = data.objectsDiff;
   const leftLabel = data.leftLabel || 'Left';
   const rightLabel = data.rightLabel || 'Right';
   const keyColumns = data.keyColumns || [];
@@ -262,6 +263,48 @@
     schemaBody.innerHTML = html;
   }
 
+  // ---- Render objects diff (indexes, constraints, triggers, sequences) ----
+  function renderObjectsDiff() {
+    var container = document.getElementById('objectsDiffContainer');
+    if (!container || !objectsDiff) return;
+
+    var sections = [
+      { key: 'indexes', title: 'Indexes' },
+      { key: 'constraints', title: 'Constraints' },
+      { key: 'triggers', title: 'Triggers' },
+      { key: 'sequences', title: 'Sequences' },
+    ];
+
+    var html = '';
+    for (var secIdx = 0; secIdx < sections.length; secIdx++) {
+      var section = sections[secIdx];
+      var items = objectsDiff[section.key];
+      if (!items || items.length === 0) continue;
+
+      html += '<h3 class="diff-section-title">' + escapeHtml(section.title) + ' (' + items.length + ')</h3>';
+      html += '<table class="diff-schema-table">';
+      html += '<thead><tr><th>Name</th><th>Left</th><th>Right</th><th>Status</th></tr></thead>';
+      html += '<tbody>';
+      for (var itemIdx = 0; itemIdx < items.length; itemIdx++) {
+        var item = items[itemIdx];
+        var rowClass = item.status === 'added' ? 'diff-added' : item.status === 'removed' ? 'diff-removed' : '';
+        var statusText = item.status;
+        if (item.differences && item.differences.length > 0) {
+          statusText += ': ' + item.differences.join(', ');
+        }
+        html += '<tr' + (rowClass ? ' class="' + rowClass + '"' : '') + '>';
+        html += '<td>' + escapeHtml(item.name) + '</td>';
+        html += '<td>' + escapeHtml(item.leftDetail || '') + '</td>';
+        html += '<td>' + escapeHtml(item.rightDetail || '') + '</td>';
+        html += '<td class="diff-status-' + escapeHtml(item.status) + '">' + escapeHtml(statusText) + '</td>';
+        html += '</tr>';
+      }
+      html += '</tbody></table>';
+    }
+
+    container.innerHTML = html;
+  }
+
   // ---- Handle messages from host ----
   window.addEventListener('message', function (event) {
     var msg = event.data;
@@ -293,4 +336,5 @@
   buildRowHeaders();
   renderRowDiff();
   renderSchemaDiff();
+  renderObjectsDiff();
 })();

--- a/src/webview/styles/diff-panel.css
+++ b/src/webview/styles/diff-panel.css
@@ -254,6 +254,16 @@ body {
   content: '\00a0';
 }
 
+/* ---- Section title (objects diff) ---- */
+.diff-section-title {
+  padding: 8px 10px 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--vscode-foreground);
+  border-top: 1px solid var(--vscode-panel-border);
+  margin-top: 8px;
+}
+
 /* ---- Schema diff table ---- */
 .diff-schema-container {
   flex: 1;


### PR DESCRIPTION
## Summary

Extends the Schema Diff tab to compare table objects beyond columns:

| Object type | PostgreSQL | SQLite | ClickHouse |
|---|---|---|---|
| **Indexes** | pg_index + pg_am (columns, unique, type, predicate) | PRAGMA index_list + index_info | system.data_skipping_indices |
| **Constraints** | information_schema (PK, UNIQUE, FK with actions, CHECK) | PRAGMA table_info + foreign_key_list | — |
| **Triggers** | pg_trigger + pg_proc (timing, events, function) | sqlite_master with SQL parsing | — |
| **Sequences** | pg_depend + pg_sequences (start, increment, min/max) | — | — |

Each section shows added (green), removed (red), changed (yellow with details), and same (dimmed) items.

## New

- `getTableObjects()` optional method on `DatabaseDriver`
- `computeObjectsDiff()` in diff engine
- `ObjectDiffItem`, `ObjectsDiffResult` types
- `IndexInfo`, `ConstraintInfo`, `TriggerInfo`, `SequenceInfo`, `TableObjects` types

## Test plan

- [x] `npm test` — 734 tests pass (+12 new)
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm run lint` — 0 new errors
- [x] `npm run build` — webpack compiles
- [ ] CI pipeline passes
- [ ] F5: compare two PG tables with different indexes/constraints