### PR TITLE
docs: restore <picture> tag for theme-adaptive banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Viewstor
 
 <p align="center">
-  <img src="resources/banner-light.png" alt="Viewstor" width="100%">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="resources/banner-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="resources/banner-light.png">
+    <img src="resources/banner-dark.png" alt="Viewstor" width="100%">
+  </picture>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Restore the `<picture>` element in README so the banner picks dark/light variant automatically based on `prefers-color-scheme`.
- `banner-dark.png` and `banner-light.png` already exist in `resources/`; previously only the light one was rendered unconditionally.

## Manual test cases
1. Open the repo on GitHub with a dark profile theme → banner shows `banner-dark.png`.
2. Open the repo with a light profile theme → banner shows `banner-light.png`.

## Checklist
- [x] README.md
- [ ] CHANGELOG.md (cosmetic README change, no user-facing extension behavior)
- [ ] CLAUDE.md
- [ ] l10n
- [ ] Wiki