### PR TITLE
feat: add Pinecone vector database driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Viewstor are documented here. Format based on [Keep a Cha
 
 ## [Unreleased]
 
+### Added
+- **Pinecone vector database driver** — browse indexes and namespaces, query vectors by similarity, upsert/delete vectors, view index statistics. Connection uses API key (no host/port). Custom command syntax: `QUERY <index> vector=[...] topK=N`, `UPSERT`, `DELETE`, `STATS`, `LIST`. Read-only mode disables upsert/delete ([#15](https://github.com/Siyet/viewstor/issues/15))
+
 ### Fixed
 - **Pagination broken after running a custom query in table mode** — editing the SQL in the table view ran the query once and showed `Page 1/1`; clicking Next silently reverted to the original table. `_runCustomTableQuery` now accepts a `page` parameter, strips the trailing `LIMIT [OFFSET]`, re-applies server-side `LIMIT pageSize OFFSET page*pageSize`, and gets the exact row count via `SELECT COUNT(*) FROM (<user query>) _sub`. Webview forwards the active custom query on every `changePage` / `changePageSize` so the host routes back to the same query instead of falling back to the default table fetch. User's explicit `LIMIT` is respected as a ceiling — e.g. `LIMIT 250` with `pageSize=100` yields exactly `100 + 100 + 50` rows across three pages, not `100 + 100 + 100`. When the count query fails (exotic SQL) pagination falls back to a "page full ⇒ probably more" heuristic. Manual ORDER BY in the SQL bar now syncs back to the header sort icons on Run. Destructive statements (VACUUM / INSERT / UPDATE / DELETE / DROP / …) are blocked at the host — only SELECT / WITH / EXPLAIN / SHOW / VALUES / TABLE are executed. Clearing the SQL bar and pressing Refresh re-populates the field with the default table SELECT so the baseline is always recoverable
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code when working with this repository.
 
 ## What is Viewstor
 
-VS Code extension for database management. Supports PostgreSQL, Redis, ClickHouse, SQLite. Free, open-source (AGPL-3.0) alternative to DBeaver/DataGrip. Follows [ZeroVer](https://0ver.org) — version 0.x until API is stable.
+VS Code extension for database management. Supports PostgreSQL, Redis, ClickHouse, SQLite, Pinecone. Free, open-source (AGPL-3.0) alternative to DBeaver/DataGrip. Follows [ZeroVer](https://0ver.org) — version 0.x until API is stable.
 
 ## Commands
 
@@ -33,7 +33,7 @@ Required methods: `connect`, `disconnect`, `ping`, `execute`, `getSchema`, `getT
 
 Optional: `getTableRowCount`, `getEstimatedRowCount` (pg_class.reltuples / system.tables), `getDDL`, `cancelQuery` (PG: pg_cancel_backend, CH: AbortController), `getCompletions` (structured: table/view/column/schema with parent), `getIndexedColumns` (pg_index query), `getTableObjects` (indexes, constraints, triggers, sequences — used by data diff), `getTableStatistics` (row count, sizes, vacuum info, scan counters — used by stats diff tab; PG uses `pg_table_size`/`pg_indexes_size` + `pg_stat_user_tables`, CH uses `system.tables` + `system.parts`, SQLite uses `COUNT(*)` + optional `dbstat` vtable).
 
-Drivers: `postgres.ts` (pg), `redis.ts` (ioredis), `clickhouse.ts` (@clickhouse/client), `sqlite.ts` (better-sqlite3).
+Drivers: `postgres.ts` (pg), `redis.ts` (ioredis), `clickhouse.ts` (@clickhouse/client), `sqlite.ts` (better-sqlite3), `pinecone.ts` (@pinecone-database/pinecone).
 
 ### Connections
 `src/connections/connectionManager.ts` — persists in VS Code `globalState` (keys: `viewstor.connections`, `viewstor.connectionFolders`).
@@ -231,3 +231,4 @@ All commands support `databaseName` parameter for multi-DB connections.
 - ClickHouse execute uses `JSON` format (not `JSONEachRow`) to get column types from response metadata
 - SQLite: file-based connection (`config.database` = file path or `:memory:`), no host/port/auth. Uses `sqlite_master` + `PRAGMA table_info()` for schema. `getEstimatedRowCount()` falls back to exact `COUNT(*)`. WAL journal mode enabled on connect (skipped for readonly). Foreign keys always enabled. Connection form shows file picker instead of host/port fields. `inferTypeFromValue()` detects column types for computed expressions (COUNT→INTEGER, SUM→REAL).
 - SQLite native module: `better-sqlite3` requires different prebuilds for Node.js (tests) and Electron (Extension Host). `scripts/sqlite-rebuild.js` manages dual builds with `prebuild-install` (NOT `electron-rebuild` which is broken). Cache in `node_modules/.cache/sqlite-builds/` with `.meta` files. `npm run dev/build/watch` auto-restores Electron binary; `npm test` switches to Node.js binary.
+- Pinecone: cloud vector database, API key auth (`config.password` = API key), no host/port. Uses `@pinecone-database/pinecone` SDK via lazy `require()`. Schema: indexes as tables, namespaces as children. Custom command parser (`parsePineconeCommand`): `QUERY <index> vector=[...] topK=N`, `UPSERT <index> id=... vector=[...]`, `DELETE <index> ids=[...]`, `STATS <index>`, `LIST <index>`. Optional methods: `getEstimatedRowCount` (describeIndexStats), `getTableStatistics`. Connection form shows API key field instead of host/port/auth.

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ All shortcuts use physical key codes — work on any keyboard layout.
 | Redis | TCP | [ioredis](https://www.npmjs.com/package/ioredis) |
 | ClickHouse | HTTP | [@clickhouse/client](https://www.npmjs.com/package/@clickhouse/client) |
 | SQLite | File | [better-sqlite3](https://www.npmjs.com/package/better-sqlite3) |
+| Pinecone | HTTPS | [@pinecone-database/pinecone](https://www.npmjs.com/package/@pinecone-database/pinecone) |
 
 ## Development
 

--- a/l10n/nls/package.nls.json
+++ b/l10n/nls/package.nls.json
@@ -1,5 +1,5 @@
 {
-  "extension.description": "Database management tool for VS Code — browse schemas, run queries, and inspect data across PostgreSQL, Redis, ClickHouse, and SQLite.",
+  "extension.description": "Database management tool for VS Code — browse schemas, run queries, and inspect data across PostgreSQL, Redis, ClickHouse, SQLite, and Pinecone.",
   "view.connections.name": "Connections",
   "view.queryHistory.name": "Query History",
   "command.addConnection": "Add Connection",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
+        "@pinecone-database/pinecone": "^7.2.0",
         "@vscode-elements/elements": "^2.5.1",
         "@vscode/codicons": "^0.0.45",
         "better-sqlite3": "^12.8.0",
@@ -1273,6 +1274,15 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@pinecone-database/pinecone": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-7.2.0.tgz",
+      "integrity": "sha512-urGsnNDWSSqSaWdyEF2P6V5bTNtRA6yMQTheFYAKKwk7mkloRBBETtT2ADF5Y8gJTr88pW5D8NTcCCLe+f0e2Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "redis",
     "clickhouse",
     "sqlite",
+    "pinecone",
+    "vector",
     "sql",
     "query",
     "schema"
@@ -81,6 +83,13 @@
         "default": {
           "fontPath": "resources/viewstor-icons.woff2",
           "fontCharacter": "\\E004"
+        }
+      },
+      "viewstor-pinecone": {
+        "description": "Pinecone",
+        "default": {
+          "fontPath": "resources/viewstor-icons.woff2",
+          "fontCharacter": "\\E005"
         }
       }
     },
@@ -628,6 +637,7 @@
     "webpack-cli": "^5.1.0"
   },
   "dependencies": {
+    "@pinecone-database/pinecone": "^7.2.0",
     "@vscode-elements/elements": "^2.5.1",
     "@vscode/codicons": "^0.0.45",
     "better-sqlite3": "^12.8.0",

--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -4,6 +4,7 @@ import { PostgresDriver } from './postgres';
 import { RedisDriver } from './redis';
 import { ClickHouseDriver } from './clickhouse';
 import { SqliteDriver } from './sqlite';
+import { PineconeDriver } from './pinecone';
 
 export function createDriver(type: DatabaseType): DatabaseDriver {
   switch (type) {
@@ -15,6 +16,8 @@ export function createDriver(type: DatabaseType): DatabaseDriver {
       return new ClickHouseDriver();
     case 'sqlite':
       return new SqliteDriver();
+    case 'pinecone':
+      return new PineconeDriver();
     default:
       throw new Error(`Unsupported database type: ${type}`);
   }

--- a/src/drivers/pinecone.ts
+++ b/src/drivers/pinecone.ts
@@ -360,10 +360,45 @@ export function parsePineconeCommand(input: string): ParsedCommand | null {
 
   const params: Record<string, string> = {};
   if (paramsStr) {
-    const paramRegex = /(\w+)=((?:\[.*?\]|\{.*?\}|"[^"]*"|'[^']*'|\S+))/g;
-    let match;
-    while ((match = paramRegex.exec(paramsStr)) !== null) {
-      params[match[1]] = match[2];
+    let pos = 0;
+    while (pos < paramsStr.length) {
+      while (pos < paramsStr.length && paramsStr[pos] === ' ') pos++;
+      if (pos >= paramsStr.length) break;
+      const eqPos = paramsStr.indexOf('=', pos);
+      if (eqPos === -1) break;
+      const key = paramsStr.substring(pos, eqPos);
+      pos = eqPos + 1;
+      if (pos >= paramsStr.length) break;
+      const ch = paramsStr[pos];
+      if (ch === '[' || ch === '{') {
+        const open = ch;
+        const close = ch === '[' ? ']' : '}';
+        let depth = 0;
+        const start = pos;
+        let inStr = false;
+        while (pos < paramsStr.length) {
+          const c = paramsStr[pos];
+          if (c === '"' && (pos === 0 || paramsStr[pos - 1] !== '\\')) inStr = !inStr;
+          else if (!inStr) {
+            if (c === open) depth++;
+            else if (c === close) depth--;
+          }
+          pos++;
+          if (depth === 0) break;
+        }
+        params[key] = paramsStr.substring(start, pos);
+      } else if (ch === '"' || ch === '\'') {
+        const quote = ch;
+        pos++;
+        const start = pos;
+        while (pos < paramsStr.length && paramsStr[pos] !== quote) pos++;
+        params[key] = paramsStr.substring(start, pos);
+        if (pos < paramsStr.length) pos++;
+      } else {
+        const start = pos;
+        while (pos < paramsStr.length && paramsStr[pos] !== ' ') pos++;
+        params[key] = paramsStr.substring(start, pos);
+      }
     }
   }
 

--- a/src/drivers/pinecone.ts
+++ b/src/drivers/pinecone.ts
@@ -1,0 +1,374 @@
+import { DatabaseDriver } from '../types/driver';
+import { ConnectionConfig } from '../types/connection';
+import { QueryResult, QueryColumn, MAX_RESULT_ROWS } from '../types/query';
+import { SchemaObject, TableInfo, TableStatistic } from '../types/schema';
+import { wrapError } from '../utils/errors';
+
+let PineconeModule: typeof import('@pinecone-database/pinecone') | undefined;
+
+function requirePinecone(): typeof import('@pinecone-database/pinecone') {
+  if (!PineconeModule) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    PineconeModule = require('@pinecone-database/pinecone');
+  }
+  return PineconeModule!;
+}
+
+type PineconeClient = InstanceType<typeof import('@pinecone-database/pinecone').Pinecone>;
+type PineconeIndex = ReturnType<PineconeClient['index']>;
+
+export class PineconeDriver implements DatabaseDriver {
+  private client: PineconeClient | undefined;
+  private indexCache: Map<string, { dimension: number; metric: string; host: string }> = new Map();
+
+  async connect(config: ConnectionConfig): Promise<void> {
+    const { Pinecone } = requirePinecone();
+    this.client = new Pinecone({ apiKey: config.password || '' });
+    const indexes = await this.client.listIndexes();
+    if (!indexes.indexes || indexes.indexes.length === 0) {
+      return;
+    }
+    this.indexCache.clear();
+    for (const idx of indexes.indexes) {
+      this.indexCache.set(idx.name, {
+        dimension: idx.dimension ?? 0,
+        metric: idx.metric,
+        host: idx.host,
+      });
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    this.client = undefined;
+    this.indexCache.clear();
+  }
+
+  async ping(): Promise<boolean> {
+    const indexes = await this.client!.listIndexes();
+    return Array.isArray(indexes.indexes);
+  }
+
+  async execute(query: string): Promise<QueryResult> {
+    const start = Date.now();
+    try {
+      const parsed = parsePineconeCommand(query);
+      if (!parsed) {
+        return { columns: [], rows: [], rowCount: 0, executionTimeMs: 0, error: 'Unsupported command. Use: QUERY <index> vector=[...] topK=N [namespace=ns] [filter={...}], UPSERT <index> id=... vector=[...] [metadata={...}] [namespace=ns], DELETE <index> ids=[...] [namespace=ns], STATS <index>, LIST <index> [namespace=ns] [prefix=...] [limit=N]' };
+      }
+
+      const index = this.getIndex(parsed.index);
+
+      switch (parsed.command) {
+        case 'QUERY': return await this.executeQuery(index, parsed, start);
+        case 'UPSERT': return await this.executeUpsert(index, parsed, start);
+        case 'DELETE': return await this.executeDelete(index, parsed, start);
+        case 'STATS': return await this.executeStats(index, start);
+        case 'LIST': return await this.executeList(index, parsed, start);
+        default:
+          return { columns: [], rows: [], rowCount: 0, executionTimeMs: Date.now() - start, error: `Unknown command: ${parsed.command}` };
+      }
+    } catch (err) {
+      return { columns: [], rows: [], rowCount: 0, executionTimeMs: Date.now() - start, error: wrapError(err) };
+    }
+  }
+
+  async getSchema(): Promise<SchemaObject[]> {
+    const indexes = await this.client!.listIndexes();
+    const result: SchemaObject[] = [];
+
+    for (const idx of indexes.indexes || []) {
+      const indexObj: SchemaObject = {
+        name: idx.name,
+        type: 'table',
+        detail: `${idx.dimension}d ${idx.metric}`,
+        children: [],
+      };
+
+      try {
+        const index = this.client!.index(idx.name);
+        const stats = await index.describeIndexStats();
+        const namespaces = stats.namespaces || {};
+        for (const [nsName, nsInfo] of Object.entries(namespaces)) {
+          indexObj.children!.push({
+            name: nsName || '(default)',
+            type: 'namespace',
+            detail: `${nsInfo.recordCount ?? 0} vectors`,
+          });
+        }
+      } catch {
+        // If stats fail, show index without namespace details
+      }
+
+      result.push(indexObj);
+    }
+
+    return result;
+  }
+
+  async getTableInfo(name: string): Promise<TableInfo> {
+    const meta = this.indexCache.get(name);
+    const columns = [
+      { name: 'id', dataType: 'string', nullable: false, isPrimaryKey: true },
+      { name: 'values', dataType: `float32[${meta?.dimension ?? '?'}]`, nullable: false, isPrimaryKey: false },
+      { name: 'metadata', dataType: 'json', nullable: true, isPrimaryKey: false },
+    ];
+
+    let rowCount: number | undefined;
+    try {
+      const index = this.client!.index(name);
+      const stats = await index.describeIndexStats();
+      rowCount = stats.totalRecordCount;
+    } catch {
+      // ignore
+    }
+
+    return { name, columns, rowCount };
+  }
+
+  async getTableData(name: string, schema?: string, limit?: number): Promise<QueryResult> {
+    const start = Date.now();
+    const ns = schema || '';
+    const pageSize = Math.min(limit || 100, MAX_RESULT_ROWS);
+
+    const index = this.client!.index(name);
+    const nsIndex = ns ? index.namespace(ns) : index;
+
+    try {
+      const listResult = await nsIndex.listPaginated({ limit: pageSize });
+      const ids = (listResult.vectors || []).map(v => v.id).filter((id): id is string => !!id);
+
+      if (ids.length === 0) {
+        return {
+          columns: [
+            { name: 'id', dataType: 'string' },
+            { name: 'values', dataType: 'float32[]' },
+            { name: 'metadata', dataType: 'json' },
+          ],
+          rows: [],
+          rowCount: 0,
+          executionTimeMs: Date.now() - start,
+        };
+      }
+
+      const fetched = await nsIndex.fetch({ ids });
+      const columns: QueryColumn[] = [
+        { name: 'id', dataType: 'string' },
+        { name: 'values', dataType: 'float32[]' },
+        { name: 'metadata', dataType: 'json' },
+      ];
+
+      const rows: Record<string, unknown>[] = [];
+      for (const id of ids) {
+        const record = fetched.records[id];
+        if (record) {
+          rows.push({
+            id: record.id,
+            values: record.values ? `[${record.values.slice(0, 8).join(', ')}${record.values.length > 8 ? ', ...' : ''}]` : null,
+            metadata: record.metadata ? JSON.stringify(record.metadata) : null,
+          });
+        }
+      }
+
+      return { columns, rows, rowCount: rows.length, executionTimeMs: Date.now() - start };
+    } catch (err) {
+      return { columns: [], rows: [], rowCount: 0, executionTimeMs: Date.now() - start, error: wrapError(err) };
+    }
+  }
+
+  async getEstimatedRowCount(name: string, schema?: string): Promise<number> {
+    const index = this.client!.index(name);
+    const stats = await index.describeIndexStats();
+    if (schema) {
+      const nsStats = stats.namespaces?.[schema];
+      return nsStats?.recordCount ?? 0;
+    }
+    return stats.totalRecordCount ?? 0;
+  }
+
+  async getTableStatistics(name: string): Promise<TableStatistic[]> {
+    const index = this.client!.index(name);
+    const stats = await index.describeIndexStats();
+    const meta = this.indexCache.get(name);
+    const result: TableStatistic[] = [
+      { key: 'row_count', label: 'Total vectors', value: stats.totalRecordCount ?? 0, unit: 'count' },
+      { key: 'dimension', label: 'Dimension', value: meta?.dimension ?? stats.dimension ?? 0, unit: 'count' },
+      { key: 'metric', label: 'Distance metric', value: meta?.metric ?? 'unknown', unit: 'text' },
+      { key: 'namespaces', label: 'Namespaces', value: Object.keys(stats.namespaces || {}).length, unit: 'count' },
+      { key: 'index_fullness', label: 'Index fullness', value: stats.indexFullness != null ? Math.round(stats.indexFullness * 10000) / 100 : null, unit: 'percent' },
+    ];
+    return result;
+  }
+
+  private getIndex(name: string): PineconeIndex {
+    return this.client!.index(name);
+  }
+
+  private async executeQuery(index: PineconeIndex, parsed: ParsedCommand, start: number): Promise<QueryResult> {
+    const vector = JSON.parse(parsed.params.vector || '[]') as number[];
+    const topK = parseInt(parsed.params.topk || parsed.params.topK || '10', 10);
+    const ns = parsed.params.namespace;
+    const filterStr = parsed.params.filter;
+    const includeMetadata = parsed.params.includeMetadata !== 'false';
+
+    const nsIndex = ns ? index.namespace(ns) : index;
+    const queryArgs: Parameters<typeof nsIndex.query>[0] = {
+      vector,
+      topK,
+      includeValues: true,
+      includeMetadata,
+    };
+    if (filterStr) {
+      queryArgs.filter = JSON.parse(filterStr);
+    }
+    const result = await nsIndex.query(queryArgs);
+
+    const columns: QueryColumn[] = [
+      { name: 'id', dataType: 'string' },
+      { name: 'score', dataType: 'float' },
+      { name: 'values', dataType: 'float32[]' },
+      { name: 'metadata', dataType: 'json' },
+    ];
+
+    const rows = result.matches.map(m => ({
+      id: m.id,
+      score: m.score ?? null,
+      values: m.values ? `[${m.values.slice(0, 8).join(', ')}${m.values.length > 8 ? ', ...' : ''}]` : null,
+      metadata: m.metadata ? JSON.stringify(m.metadata) : null,
+    }));
+
+    return { columns, rows, rowCount: rows.length, executionTimeMs: Date.now() - start };
+  }
+
+  private async executeUpsert(index: PineconeIndex, parsed: ParsedCommand, start: number): Promise<QueryResult> {
+    const id = parsed.params.id;
+    const vector = JSON.parse(parsed.params.vector || '[]');
+    const ns = parsed.params.namespace;
+    const metadataStr = parsed.params.metadata;
+
+    if (!id) {
+      return { columns: [], rows: [], rowCount: 0, executionTimeMs: Date.now() - start, error: 'id is required for UPSERT' };
+    }
+
+    const record: { id: string; values: number[]; metadata?: Record<string, string | number | boolean | string[]> } = { id, values: vector };
+    if (metadataStr) {
+      record.metadata = JSON.parse(metadataStr);
+    }
+
+    const nsIndex = ns ? index.namespace(ns) : index;
+    await nsIndex.upsert({ records: [record] });
+
+    return {
+      columns: [{ name: 'result', dataType: 'string' }],
+      rows: [{ result: `Upserted vector "${id}"` }],
+      rowCount: 1,
+      affectedRows: 1,
+      executionTimeMs: Date.now() - start,
+    };
+  }
+
+  private async executeDelete(index: PineconeIndex, parsed: ParsedCommand, start: number): Promise<QueryResult> {
+    const idsStr = parsed.params.ids;
+    const ns = parsed.params.namespace;
+    const deleteAll = parsed.params.deleteAll === 'true' || parsed.params.all === 'true';
+
+    const nsIndex = ns ? index.namespace(ns) : index;
+
+    if (deleteAll) {
+      await nsIndex.deleteAll();
+      return {
+        columns: [{ name: 'result', dataType: 'string' }],
+        rows: [{ result: 'Deleted all vectors' + (ns ? ` in namespace "${ns}"` : '') }],
+        rowCount: 1,
+        executionTimeMs: Date.now() - start,
+      };
+    }
+
+    if (!idsStr) {
+      return { columns: [], rows: [], rowCount: 0, executionTimeMs: Date.now() - start, error: 'ids=[...] or all=true is required for DELETE' };
+    }
+
+    const ids = JSON.parse(idsStr);
+    await nsIndex.deleteMany(ids);
+
+    return {
+      columns: [{ name: 'result', dataType: 'string' }],
+      rows: [{ result: `Deleted ${ids.length} vector(s)` }],
+      rowCount: 1,
+      affectedRows: ids.length,
+      executionTimeMs: Date.now() - start,
+    };
+  }
+
+  private async executeStats(index: PineconeIndex, start: number): Promise<QueryResult> {
+    const stats = await index.describeIndexStats();
+    const columns: QueryColumn[] = [
+      { name: 'metric', dataType: 'string' },
+      { name: 'value', dataType: 'string' },
+    ];
+
+    const rows: Record<string, unknown>[] = [
+      { metric: 'Total vectors', value: stats.totalRecordCount },
+      { metric: 'Dimension', value: stats.dimension },
+      { metric: 'Index fullness', value: stats.indexFullness != null ? `${Math.round(stats.indexFullness * 100)}%` : 'N/A' },
+    ];
+
+    for (const [nsName, nsInfo] of Object.entries(stats.namespaces || {})) {
+      rows.push({ metric: `Namespace "${nsName || '(default)'}"`, value: `${nsInfo.recordCount ?? 0} vectors` });
+    }
+
+    return { columns, rows, rowCount: rows.length, executionTimeMs: Date.now() - start };
+  }
+
+  private async executeList(index: PineconeIndex, parsed: ParsedCommand, start: number): Promise<QueryResult> {
+    const ns = parsed.params.namespace;
+    const prefix = parsed.params.prefix;
+    const limit = parseInt(parsed.params.limit || '100', 10);
+
+    const nsIndex = ns ? index.namespace(ns) : index;
+    const listArgs: { limit: number; prefix?: string } = { limit: Math.min(limit, MAX_RESULT_ROWS) };
+    if (prefix) listArgs.prefix = prefix;
+
+    const result = await nsIndex.listPaginated(listArgs);
+    const ids = (result.vectors || []).map(v => v.id).filter((id): id is string => !!id);
+
+    const columns: QueryColumn[] = [{ name: 'id', dataType: 'string' }];
+    const rows = ids.map(id => ({ id }));
+
+    return { columns, rows, rowCount: rows.length, executionTimeMs: Date.now() - start };
+  }
+}
+
+interface ParsedCommand {
+  command: string;
+  index: string;
+  params: Record<string, string>;
+}
+
+export function parsePineconeCommand(input: string): ParsedCommand | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const firstSpace = trimmed.indexOf(' ');
+  if (firstSpace === -1) return null;
+
+  const command = trimmed.substring(0, firstSpace).toUpperCase();
+  const rest = trimmed.substring(firstSpace + 1).trim();
+
+  const secondSpace = rest.indexOf(' ');
+  const index = secondSpace === -1 ? rest : rest.substring(0, secondSpace);
+  const paramsStr = secondSpace === -1 ? '' : rest.substring(secondSpace + 1).trim();
+
+  const params: Record<string, string> = {};
+  if (paramsStr) {
+    const paramRegex = /(\w+)=((?:\[.*?\]|\{.*?\}|"[^"]*"|'[^']*'|\S+))/g;
+    let match;
+    while ((match = paramRegex.exec(paramsStr)) !== null) {
+      params[match[1]] = match[2];
+    }
+  }
+
+  const validCommands = ['QUERY', 'UPSERT', 'DELETE', 'STATS', 'LIST'];
+  if (!validCommands.includes(command)) return null;
+
+  return { command, index, params };
+}

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -185,7 +185,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const { connectionId, query, database } = args as { connectionId: string; query: string; database?: string };
         const config = store.get(connectionId);
         if (config?.readonly && !isReadOnlyQuery(query)) {
-          return errorResponse('Connection is read-only. Only SELECT, EXPLAIN, SHOW, and WITH queries are allowed.');
+          return errorResponse('Connection is read-only. Only SELECT, EXPLAIN, SHOW, WITH, and read-only driver commands (QUERY, STATS, LIST) are allowed.');
         }
         const driver = await resolveDriver(connectionId, database);
         return jsonResponse(formatExecuteQuery(await driver.execute(query)));

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -86,16 +86,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'add_connection',
-      description: 'Add a new database connection. For SQLite: set type="sqlite", database="/path/to/file.db" (or ":memory:"), host and port are ignored.',
+      description: 'Add a new database connection. For SQLite: set type="sqlite", database="/path/to/file.db" (or ":memory:"), host and port are ignored. For Pinecone: set type="pinecone", password=API key, host and port are ignored.',
       inputSchema: {
         type: 'object' as const,
         properties: {
           name: { type: 'string', description: 'Display name' },
-          type: { type: 'string', enum: ['postgresql', 'redis', 'clickhouse', 'sqlite'], description: 'Database type' },
-          host: { type: 'string', description: 'Host (ignored for SQLite)' },
-          port: { type: 'number', description: 'Port (ignored for SQLite)' },
+          type: { type: 'string', enum: ['postgresql', 'redis', 'clickhouse', 'sqlite', 'pinecone'], description: 'Database type' },
+          host: { type: 'string', description: 'Host (ignored for SQLite and Pinecone)' },
+          port: { type: 'number', description: 'Port (ignored for SQLite and Pinecone)' },
           username: { type: 'string', description: 'Username' },
-          password: { type: 'string', description: 'Password' },
+          password: { type: 'string', description: 'Password (API key for Pinecone)' },
           database: { type: 'string', description: 'Database name, or file path for SQLite (e.g. "/tmp/test.db", ":memory:")' },
           ssl: { type: 'boolean', description: 'Use SSL' },
           readonly: { type: 'boolean', description: 'Read-only mode' },

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -83,6 +83,7 @@ function mapDBeaverProvider(provider?: string, driver?: string): DatabaseType | 
   if (p.includes('redis') || p.includes('iredis')) return 'redis';
   if (p.includes('clickhouse')) return 'clickhouse';
   if (p.includes('sqlite')) return 'sqlite';
+  if (p.includes('pinecone')) return 'pinecone';
   return null;
 }
 
@@ -146,6 +147,7 @@ function mapDataGripDriver(driver?: string): DatabaseType | null {
   if (d.includes('redis')) return 'redis';
   if (d.includes('clickhouse')) return 'clickhouse';
   if (d.includes('sqlite')) return 'sqlite';
+  if (d.includes('pinecone')) return 'pinecone';
   return null;
 }
 

--- a/src/test/driverContract.test.ts
+++ b/src/test/driverContract.test.ts
@@ -27,10 +27,15 @@ vi.mock('ssh2', () => ({
   Client: class MockSSHClient {},
 }));
 
+vi.mock('@pinecone-database/pinecone', () => ({
+  Pinecone: class MockPinecone {},
+}));
+
 import { PostgresDriver } from '../drivers/postgres';
 import { RedisDriver } from '../drivers/redis';
 import { ClickHouseDriver } from '../drivers/clickhouse';
 import { SqliteDriver } from '../drivers/sqlite';
+import { PineconeDriver } from '../drivers/pinecone';
 import { createDriver } from '../drivers';
 import type { DatabaseDriver } from '../types/driver';
 
@@ -57,7 +62,7 @@ const OPTIONAL_METHODS: (keyof DatabaseDriver)[] = [
 
 interface DriverSpec {
   name: string;
-  type: 'postgresql' | 'redis' | 'clickhouse' | 'sqlite';
+  type: 'postgresql' | 'redis' | 'clickhouse' | 'sqlite' | 'pinecone';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   DriverClass: new (...args: any[]) => DatabaseDriver;
   expectedOptional: (keyof DatabaseDriver)[];
@@ -110,6 +115,15 @@ const DRIVER_SPECS: DriverSpec[] = [
       'getTableRowCount',
       'getEstimatedRowCount',
       'getTableObjects',
+      'getTableStatistics',
+    ],
+  },
+  {
+    name: 'PineconeDriver',
+    type: 'pinecone',
+    DriverClass: PineconeDriver,
+    expectedOptional: [
+      'getEstimatedRowCount',
       'getTableStatistics',
     ],
   },

--- a/src/test/pineconeParser.test.ts
+++ b/src/test/pineconeParser.test.ts
@@ -92,4 +92,22 @@ describe('parsePineconeCommand', () => {
       params: {},
     });
   });
+
+  it('handles nested JSON in filter param', () => {
+    const result = parsePineconeCommand('QUERY idx vector=[1,2] filter={"$and":[{"genre":"comedy"},{"year":{"$gte":2020}}]}');
+    expect(result).toEqual({
+      command: 'QUERY',
+      index: 'idx',
+      params: { vector: '[1,2]', filter: '{"$and":[{"genre":"comedy"},{"year":{"$gte":2020}}]}' },
+    });
+  });
+
+  it('handles nested arrays in vector param', () => {
+    const result = parsePineconeCommand('UPSERT idx id=v1 vector=[0.1,0.2,0.3] metadata={"tags":["a","b"]}');
+    expect(result).toEqual({
+      command: 'UPSERT',
+      index: 'idx',
+      params: { id: 'v1', vector: '[0.1,0.2,0.3]', metadata: '{"tags":["a","b"]}' },
+    });
+  });
 });

--- a/src/test/pineconeParser.test.ts
+++ b/src/test/pineconeParser.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { parsePineconeCommand } from '../drivers/pinecone';
+
+describe('parsePineconeCommand', () => {
+  it('returns null for empty input', () => {
+    expect(parsePineconeCommand('')).toBeNull();
+    expect(parsePineconeCommand('   ')).toBeNull();
+  });
+
+  it('returns null for single word (no index)', () => {
+    expect(parsePineconeCommand('QUERY')).toBeNull();
+  });
+
+  it('returns null for unknown commands', () => {
+    expect(parsePineconeCommand('SELECT my-index')).toBeNull();
+    expect(parsePineconeCommand('INSERT my-index id=1')).toBeNull();
+  });
+
+  it('parses QUERY with vector and topK', () => {
+    const result = parsePineconeCommand('QUERY my-index vector=[0.1,0.2,0.3] topK=5');
+    expect(result).toEqual({
+      command: 'QUERY',
+      index: 'my-index',
+      params: { vector: '[0.1,0.2,0.3]', topK: '5' },
+    });
+  });
+
+  it('parses QUERY with namespace and filter', () => {
+    const result = parsePineconeCommand('QUERY idx vector=[1,2] namespace=ns1 filter={"genre":"comedy"}');
+    expect(result).toEqual({
+      command: 'QUERY',
+      index: 'idx',
+      params: { vector: '[1,2]', namespace: 'ns1', filter: '{"genre":"comedy"}' },
+    });
+  });
+
+  it('parses UPSERT with id, vector, and metadata', () => {
+    const result = parsePineconeCommand('UPSERT my-index id=vec1 vector=[0.1,0.2] metadata={"key":"val"}');
+    expect(result).toEqual({
+      command: 'UPSERT',
+      index: 'my-index',
+      params: { id: 'vec1', vector: '[0.1,0.2]', metadata: '{"key":"val"}' },
+    });
+  });
+
+  it('parses DELETE with ids', () => {
+    const result = parsePineconeCommand('DELETE my-index ids=["id1","id2"]');
+    expect(result).toEqual({
+      command: 'DELETE',
+      index: 'my-index',
+      params: { ids: '["id1","id2"]' },
+    });
+  });
+
+  it('parses DELETE with all=true', () => {
+    const result = parsePineconeCommand('DELETE my-index all=true namespace=ns1');
+    expect(result).toEqual({
+      command: 'DELETE',
+      index: 'my-index',
+      params: { all: 'true', namespace: 'ns1' },
+    });
+  });
+
+  it('parses STATS with index only', () => {
+    const result = parsePineconeCommand('STATS my-index');
+    expect(result).toEqual({
+      command: 'STATS',
+      index: 'my-index',
+      params: {},
+    });
+  });
+
+  it('parses LIST with namespace and prefix', () => {
+    const result = parsePineconeCommand('LIST my-index namespace=ns1 prefix=doc_ limit=50');
+    expect(result).toEqual({
+      command: 'LIST',
+      index: 'my-index',
+      params: { namespace: 'ns1', prefix: 'doc_', limit: '50' },
+    });
+  });
+
+  it('is case-insensitive for command', () => {
+    const result = parsePineconeCommand('query my-index vector=[1]');
+    expect(result?.command).toBe('QUERY');
+  });
+
+  it('handles extra whitespace', () => {
+    const result = parsePineconeCommand('  STATS   my-index  ');
+    expect(result).toEqual({
+      command: 'STATS',
+      index: 'my-index',
+      params: {},
+    });
+  });
+});

--- a/src/test/queryHelpers.test.ts
+++ b/src/test/queryHelpers.test.ts
@@ -68,6 +68,9 @@ describe('isReadOnlyQuery — happy path', () => {
     'DESCRIBE users',
     'DESC users',
     '  SELECT 1  ',
+    'QUERY my-index vector=[0.1,0.2] topK=5',
+    'STATS my-index',
+    'LIST my-index namespace=ns1',
   ])('accepts %s', (sql) => {
     expect(isReadOnlyQuery(sql)).toBe(true);
   });

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -1,4 +1,4 @@
-export type DatabaseType = 'postgresql' | 'redis' | 'clickhouse' | 'sqlite';
+export type DatabaseType = 'postgresql' | 'redis' | 'clickhouse' | 'sqlite' | 'pinecone';
 
 export interface ConnectionConfig {
   id: string;
@@ -66,4 +66,5 @@ export const DEFAULT_PORTS: Record<DatabaseType, number> = {
   redis: 6379,
   clickhouse: 8123,
   sqlite: 0,
+  pinecone: 0,
 };

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -25,7 +25,8 @@ export type SchemaObjectType =
   | 'keyspace'
   | 'trigger'
   | 'sequence'
-  | 'group';
+  | 'group'
+  | 'namespace';
 
 export interface ColumnInfo {
   name: string;

--- a/src/utils/queryHelpers.ts
+++ b/src/utils/queryHelpers.ts
@@ -1,6 +1,6 @@
 import { DatabaseDriver } from '../types/driver';
 
-const READ_VERB_RE = /^\s*(SELECT|WITH|EXPLAIN|SHOW|VALUES|TABLE|DESCRIBE|DESC)\b/i;
+const READ_VERB_RE = /^\s*(SELECT|WITH|EXPLAIN|SHOW|VALUES|TABLE|DESCRIBE|DESC|QUERY|STATS|LIST)\b/i;
 // Verbs that mutate state — anywhere they appear (CTE body, EXPLAIN target, etc.) the statement is NOT read-only.
 const WRITE_VERB_RE = /\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|GRANT|REVOKE|MERGE|COPY|REPLACE|VACUUM|REFRESH|REINDEX|CALL|LOCK|NOTIFY|LISTEN|UNLISTEN|RESET|COMMIT|ROLLBACK|SAVEPOINT)\b/i;
 // PG: EXPLAIN ANALYZE actually executes the inner statement. ANALYZE may sit inside a parenthesized option list.

--- a/src/views/connectionForm.ts
+++ b/src/views/connectionForm.ts
@@ -232,6 +232,7 @@ export class ConnectionFormPanel {
         <vscode-option value="redis"${c?.type === 'redis' ? ' selected' : ''}>Redis</vscode-option>
         <vscode-option value="clickhouse"${c?.type === 'clickhouse' ? ' selected' : ''}>ClickHouse</vscode-option>
         <vscode-option value="sqlite"${c?.type === 'sqlite' ? ' selected' : ''}>SQLite</vscode-option>
+        <vscode-option value="pinecone"${c?.type === 'pinecone' ? ' selected' : ''}>Pinecone</vscode-option>
       </vscode-single-select>
     </div>
 
@@ -278,6 +279,14 @@ export class ConnectionFormPanel {
       <vscode-textfield id="sqliteFile" placeholder="/path/to/database.sqlite" value="${c?.type === 'sqlite' ? esc(c?.database) : ''}"></vscode-textfield>
       <div class="field-hint">
         Path to an existing .sqlite/.db file, or a new file to create. Use <code>:memory:</code> for in-memory database.
+      </div>
+    </div>
+
+    <div id="pineconeApiKeyField" class="form-group hidden">
+      <label for="pineconeApiKey">API Key</label>
+      <vscode-textfield id="pineconeApiKey" type="password" placeholder="pcsk_..." value="${c?.type === 'pinecone' ? esc(c?.password) : ''}"></vscode-textfield>
+      <div class="field-hint">
+        Pinecone API key from the <a href="https://app.pinecone.io">Pinecone console</a>. Stored as connection password.
       </div>
     </div>
 

--- a/src/views/connectionTree.ts
+++ b/src/views/connectionTree.ts
@@ -315,6 +315,7 @@ function schemaIcon(type: SchemaObjectType): string {
     case 'trigger': return 'zap';
     case 'sequence': return 'symbol-number';
     case 'group': return 'list-flat';
+    case 'namespace': return 'symbol-namespace';
     default: return 'symbol-misc';
   }
 }

--- a/src/webview/scripts/connection-form.js
+++ b/src/webview/scripts/connection-form.js
@@ -2,7 +2,7 @@
 (function () {
   const vscode = acquireVsCodeApi();
 
-  const defaultPorts = { postgresql: 5432, redis: 6379, clickhouse: 8123, sqlite: 0 };
+  const defaultPorts = { postgresql: 5432, redis: 6379, clickhouse: 8123, sqlite: 0, pinecone: 0 };
 
   // VS Code custom elements expose `value` / `checked` properties just like
   // native form controls and emit `change` / `input` events. Wrappers below
@@ -56,16 +56,19 @@
   function updateFieldVisibility() {
     const isRedis = dbType.value === 'redis';
     const isSqlite = dbType.value === 'sqlite';
-    const isNetworkDb = !isRedis && !isSqlite;
+    const isPinecone = dbType.value === 'pinecone';
+    const isNetworkDb = !isRedis && !isSqlite && !isPinecone;
     authFields.style.display = isNetworkDb ? 'block' : 'none';
     dbFields.style.display = isNetworkDb ? 'block' : 'none';
-    if (hostPortRow) hostPortRow.style.display = isSqlite ? 'none' : '';
+    if (hostPortRow) hostPortRow.style.display = (isSqlite || isPinecone) ? 'none' : '';
     redisDbField.classList.toggle('hidden', !isRedis);
     sqliteFileField.classList.toggle('hidden', !isSqlite);
-    if (sslGroup) sslGroup.style.display = isSqlite ? 'none' : '';
-    if (proxyGroup) proxyGroup.style.display = isSqlite ? 'none' : '';
+    var pineconeApiKeyField = $('pineconeApiKeyField');
+    if (pineconeApiKeyField) pineconeApiKeyField.classList.toggle('hidden', !isPinecone);
+    if (sslGroup) sslGroup.style.display = (isSqlite || isPinecone) ? 'none' : '';
+    if (proxyGroup) proxyGroup.style.display = (isSqlite || isPinecone) ? 'none' : '';
     const hiddenSchemasGroup = $('hiddenSchemasGroup');
-    if (hiddenSchemasGroup) hiddenSchemasGroup.style.display = isSqlite ? 'none' : '';
+    if (hiddenSchemasGroup) hiddenSchemasGroup.style.display = (isSqlite || isPinecone) ? 'none' : '';
     updateProxyVisibility();
   }
 
@@ -246,6 +249,7 @@
   function getFormData() {
     const isRedis = dbType.value === 'redis';
     const isSqlite = dbType.value === 'sqlite';
+    const isPinecone = dbType.value === 'pinecone';
     return {
       id: connId.value || '',
       name: valueOf(connName).trim(),
@@ -253,9 +257,9 @@
       host: valueOf(host).trim(),
       port: valueOf(port),
       username: valueOf(username).trim(),
-      password: valueOf(password),
+      password: isPinecone ? valueOf($('pineconeApiKey')) : valueOf(password),
       database: isRedis ? valueOf(redisDb) : isSqlite ? valueOf(sqliteFile).trim() : database.value.trim(),
-      databases: (isRedis || isSqlite) ? '' : databases.value.trim(),
+      databases: (isRedis || isSqlite || isPinecone) ? '' : databases.value.trim(),
       ssl: ssl.checked ? 'true' : 'false',
       color: colorPicker.getValue(),
       readonly: readonlyMode.checked ? 'true' : 'false',
@@ -287,10 +291,14 @@
   function validate() {
     let valid = true;
     const isSqlite = dbType.value === 'sqlite';
+    const isPinecone = dbType.value === 'pinecone';
     document.querySelectorAll('.error-text').forEach(function (el) { el.remove(); });
 
     if (!valueOf(connName).trim()) { showError(connName, 'Connection name is required'); valid = false; }
-    if (isSqlite) {
+    if (isPinecone) {
+      var apiKey = $('pineconeApiKey');
+      if (apiKey && !valueOf(apiKey).trim()) { showError(apiKey, 'API key is required'); valid = false; }
+    } else if (isSqlite) {
       if (!valueOf(sqliteFile).trim()) { showError(sqliteFile, 'Database file path is required'); valid = false; }
     } else {
       if (!valueOf(host).trim()) { showError(host, 'Host is required'); valid = false; }
@@ -342,6 +350,7 @@
           databases.value = (c.databases || []).join(',');
           if (c.type === 'redis') redisDb.value = c.database || '0';
           if (c.type === 'sqlite') sqliteFile.value = c.database || '';
+          if (c.type === 'pinecone' && $('pineconeApiKey')) $('pineconeApiKey').value = c.password || '';
           initChips();
           ssl.checked = !!c.ssl;
           colorPicker.setValue(c.color || '');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ module.exports = (_env, argv) => {
       ssh2: 'commonjs ssh2',
       'cpu-features': 'commonjs cpu-features',
       'better-sqlite3': 'commonjs better-sqlite3',
+      '@pinecone-database/pinecone': 'commonjs @pinecone-database/pinecone',
     },
     plugins: [
       new webpack.DefinePlugin({ __DEV__: JSON.stringify(isDev) }),
@@ -66,6 +67,7 @@ module.exports = (_env, argv) => {
       ssh2: 'commonjs ssh2',
       'cpu-features': 'commonjs cpu-features',
       'better-sqlite3': 'commonjs better-sqlite3',
+      '@pinecone-database/pinecone': 'commonjs @pinecone-database/pinecone',
     },
     plugins: [
       new webpack.DefinePlugin({ __DEV__: JSON.stringify(isDev) }),


### PR DESCRIPTION
## Summary
- Full `PineconeDriver` implementation using `@pinecone-database/pinecone` SDK — browse indexes and namespaces, query vectors by similarity, upsert/delete vectors, view index statistics
- Integrated across all touchpoints: connection form (API key field, no host/port), driver factory, MCP standalone server, import service (DBeaver + DataGrip), tree view (namespace icon), webpack externals
- Custom command syntax via `parsePineconeCommand`: `QUERY <index> vector=[...] topK=N`, `UPSERT <index> id=... vector=[...]`, `DELETE <index> ids=[...]`, `STATS <index>`, `LIST <index>`

Closes #15

## Assumptions
- **API key stored as `config.password`.** Pinecone uses API key auth with no username. The connection form shows a dedicated "API Key" field that maps to the password field internally, consistent with how Redis stores its password.
- **No host/port fields.** Pinecone is a managed cloud service; the SDK resolves endpoints from the API key. The connection form hides host/port/SSL/proxy when Pinecone is selected.
- **Custom command parser, not SQL.** Like Redis, Pinecone doesn't use SQL. The `execute()` method parses a custom syntax: `COMMAND index-name key=value ...`. JSON arrays/objects in params are supported for vectors, metadata, and filters.
- **Lazy require.** The `@pinecone-database/pinecone` SDK is loaded via lazy `require()` to avoid blocking extension activation, following the same pattern as other drivers.
- **Icon uses next available font character.** `\E005` is used for the `viewstor-pinecone` icon in the existing `viewstor-icons.woff2` font. If the glyph doesn't exist yet, the icon will fall back to the default; the font file needs a corresponding glyph added separately.
- **No Grafana export.** Pinecone has no Grafana datasource plugin, so it's excluded from `DB_TYPE_TO_GRAFANA_DS`.
- **No safe mode.** Pinecone doesn't support EXPLAIN, so safe mode checks are not applicable (the existing `isSafeModeDB` check already excludes unknown types).
- **Mock-based tests only.** No free tier suitable for CI; unit tests cover the command parser (12 tests) and driver contract verification.

## Manual test cases
- **Golden path**: Add Connection → select "Pinecone" → enter API key → Test Connection → Save → expand tree (indexes with dimension/metric detail, namespaces with vector counts) → click an index → Result Panel shows id/values/metadata columns
- **Query vectors**: Open query editor on Pinecone connection → `QUERY my-index vector=[0.1,0.2,0.3] topK=5` → results show id, score, truncated values, metadata JSON
- **Upsert**: `UPSERT my-index id=test-1 vector=[0.1,0.2] metadata={"key":"val"}` → success message
- **Delete**: `DELETE my-index ids=["test-1"]` → success message with count
- **Stats**: `STATS my-index` → table with total vectors, dimension, metric, namespaces, index fullness
- **List**: `LIST my-index namespace=ns1 prefix=doc_ limit=10` → list of vector IDs
- **Read-only mode**: Mark connection read-only → upsert/delete should fail at the host level (readonly check)
- **Invalid command**: `SELECT * FROM my-index` → error message with supported command syntax
- **MCP**: `add_connection` with `type: "pinecone"`, `password: "<api-key>"` → connection created successfully

## Checklist
- [x] README — added Pinecone row to Supported Databases table
- [x] CHANGELOG — added entry under `[Unreleased] > Added`
- [x] CLAUDE.md — updated "What is Viewstor", Drivers list, Key Conventions with Pinecone-specific notes
- [x] l10n — extension description includes Pinecone
- [ ] Wiki — new Pinecone driver section (note: cannot push wiki from PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_014crKND1GKTVNv2GGTGXZSw)_