### PR TITLE
feat(mcp): restrict add_connection tool with allowAddConnection setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Viewstor are documented here. Format based on [Keep a Cha
 
 ## [Unreleased]
 
+### Changed
+- **Standalone MCP: restrict `add_connection` tool** — agents can no longer silently create writeable connections that bypass `readonly`, `agentAccess`, and `agentWriteApproval` gates. New `allowAddConnection` setting in `~/.viewstor/connections.json` (`'off' | 'restricted' | 'unrestricted'`, default `'restricted'`). In restricted mode, agent-created connections are forced `readonly: true`, `scope: 'project'` (passwords stripped), and name-prefixed `[agent] `. In off mode the tool is removed entirely. Tree view shows an `agent` badge on agent-created connections. ([#119](https://github.com/Siyet/viewstor/issues/119))
+
 ## [0.4.0] — 2026-04-29
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,11 @@ All auto-connect. Returns structured JSON or `{ error }`.
 ### Standalone MCP Server
 `src/mcp-server/index.ts` — stdio-based MCP server for CLI agents (Claude Code, etc.). Built as separate webpack entry → `dist/mcp-server.js`. Uses `@modelcontextprotocol/sdk`. Does NOT import `vscode`.
 
-`src/mcp-server/connectionStore.ts` — reads connections from `~/.viewstor/connections.json` (user) and `.vscode/viewstor.json` (project). Manages driver lifecycle.
+`src/mcp-server/connectionStore.ts` — reads connections from `~/.viewstor/connections.json` (user) and `.vscode/viewstor.json` (project). Manages driver lifecycle. Also reads `settings` from the user config: `StandaloneMcpSettings` with `allowAddConnection` (`'off' | 'restricted' | 'unrestricted'`, default `'restricted'`). `saveProjectConfig()` writes project-scoped connections to `.vscode/viewstor.json` with passwords stripped.
 
 9 tools: `list_connections`, `get_schema`, `execute_query`, `get_table_data`, `get_table_info`, `add_connection`, `reload_connections`, `build_chart`, `export_grafana_dashboard`.
+
+`add_connection` is gated by `allowAddConnection` setting: `'off'` removes the tool from `ListToolsRequestSchema` and returns an error; `'restricted'` (default) forces `readonly: true`, `scope: 'project'`, name prefix `[agent] `, and sets `agentCreated: true`; `'unrestricted'` preserves today's behavior with a warning. `ConnectionConfig.agentCreated` marks agent-created connections; the tree view shows an `agent` badge on them.
 
 Data-oriented tools (`execute_query`, `get_schema`, `get_table_data`, `get_table_info`, `build_chart`) accept an optional `database` parameter. `ConnectionStore.ensureDriverForDatabase()` mirrors `ConnectionManager.getDriverForDatabase()` — caches per `connectionId:database`, reuses host/user/password/ssl. VS Code MCP commands accept `database` as a trailing optional arg.
 

--- a/README.md
+++ b/README.md
@@ -222,9 +222,14 @@ Or add manually:
 }
 ```
 
-9 tools: `list_connections`, `get_schema`, `execute_query`, `get_table_data`, `get_table_info`, `add_connection`, `reload_connections`, `build_chart`. Reads connections from `~/.viewstor/connections.json` and `.vscode/viewstor.json`. Connections sync bidirectionally with the VS Code extension. See the [MCP Server wiki page](https://github.com/Siyet/viewstor/wiki/MCP-Server) for setup instructions.
+9 tools: `list_connections`, `get_schema`, `execute_query`, `get_table_data`, `get_table_info`, `add_connection`, `reload_connections`, `build_chart`, `export_grafana_dashboard`. Reads connections from `~/.viewstor/connections.json` and `.vscode/viewstor.json`. Connections sync bidirectionally with the VS Code extension. See the [MCP Server wiki page](https://github.com/Siyet/viewstor/wiki/MCP-Server) for setup instructions.
 
 All MCP interfaces auto-connect and respect read-only mode.
+
+**`add_connection` safety modes** — controlled by `settings.allowAddConnection` in `~/.viewstor/connections.json`:
+- `"restricted"` (default): agent-created connections are forced read-only, project-scoped (password stripped), and prefixed `[agent] `.
+- `"off"`: tool removed entirely — agents cannot create connections.
+- `"unrestricted"`: no restrictions (opt-in only).
 
 Data-oriented tools (`execute_query`, `get_schema`, `get_table_data`, `get_table_info`, `build_chart`) accept an optional `database` parameter — query another database on the same server without creating a new connection or re-entering the password.
 

--- a/l10n/nls/package.nls.json
+++ b/l10n/nls/package.nls.json
@@ -52,5 +52,9 @@
   "command.compareWith": "Compare With...",
   "command.compareData": "Compare Data",
   "config.diffRowLimit.description": "Maximum number of rows to compare per table. Larger values use more memory.",
-  "command.showOnMap": "Show on Map"
+  "command.showOnMap": "Show on Map",
+  "config.standaloneMcp.allowAddConnection.description": "Controls whether CLI agents can create database connections via the standalone MCP add_connection tool. 'restricted' forces read-only, project-scoped connections; 'off' disables the tool entirely.",
+  "config.standaloneMcp.allowAddConnection.off": "Tool removed — agents cannot create connections",
+  "config.standaloneMcp.allowAddConnection.restricted": "Agent-created connections are forced read-only, project-scoped, and prefixed [agent] (default)",
+  "config.standaloneMcp.allowAddConnection.unrestricted": "No restrictions — agents can create writeable connections (use with caution)"
 }

--- a/package.json
+++ b/package.json
@@ -573,6 +573,21 @@
           "minimum": 100,
           "maximum": 100000,
           "description": "%config.diffRowLimit.description%"
+        },
+        "viewstor.standaloneMcp.allowAddConnection": {
+          "type": "string",
+          "default": "restricted",
+          "enum": [
+            "off",
+            "restricted",
+            "unrestricted"
+          ],
+          "enumDescriptions": [
+            "%config.standaloneMcp.allowAddConnection.off%",
+            "%config.standaloneMcp.allowAddConnection.restricted%",
+            "%config.standaloneMcp.allowAddConnection.unrestricted%"
+          ],
+          "description": "%config.standaloneMcp.allowAddConnection.description%"
         }
       }
     },

--- a/src/mcp-server/connectionStore.ts
+++ b/src/mcp-server/connectionStore.ts
@@ -162,8 +162,17 @@ export class ConnectionStore {
       fs.mkdirSync(USER_CONFIG_DIR, { recursive: true });
     }
 
-    const data: ConfigData = { connections: userConfigs };
-    fs.writeFileSync(USER_CONFIG_FILE, JSON.stringify(data, null, 2), 'utf8');
+    let existing: ConfigData = { connections: [] };
+    try {
+      if (fs.existsSync(USER_CONFIG_FILE)) {
+        existing = JSON.parse(fs.readFileSync(USER_CONFIG_FILE, 'utf8'));
+      }
+    } catch {
+      // invalid JSON — overwrite
+    }
+
+    existing.connections = userConfigs;
+    fs.writeFileSync(USER_CONFIG_FILE, JSON.stringify(existing, null, 2), 'utf8');
   }
 
   private async saveProjectConfig() {

--- a/src/mcp-server/connectionStore.ts
+++ b/src/mcp-server/connectionStore.ts
@@ -10,9 +10,14 @@ const USER_CONFIG_DIR = path.join(os.homedir(), '.viewstor');
 const USER_CONFIG_FILE = path.join(USER_CONFIG_DIR, 'connections.json');
 const PROJECT_CONFIG_FILE = '.vscode/viewstor.json';
 
+export interface StandaloneMcpSettings {
+  allowAddConnection?: 'off' | 'restricted' | 'unrestricted';
+}
+
 interface ConfigData {
   connections: ConnectionConfig[];
   folders?: ConnectionFolder[];
+  settings?: StandaloneMcpSettings;
 }
 
 export class ConnectionStore {
@@ -21,6 +26,7 @@ export class ConnectionStore {
   private drivers = new Map<string, DatabaseDriver>();
   private dbDrivers = new Map<string, DatabaseDriver>();
   private dbDriverLocks = new Map<string, Promise<DatabaseDriver>>();
+  private settings: StandaloneMcpSettings = {};
 
   constructor() {
     this.reload();
@@ -29,12 +35,17 @@ export class ConnectionStore {
   reload() {
     this.connections.clear();
     this.folders.clear();
+    this.settings = {};
     // Load user-level config
     this.loadFile(USER_CONFIG_FILE, 'user');
 
     // Load project-level config
     const projectFile = path.join(process.cwd(), PROJECT_CONFIG_FILE);
     this.loadFile(projectFile, 'project');
+  }
+
+  getSettings(): StandaloneMcpSettings {
+    return this.settings;
   }
 
   private loadFile(filePath: string, scope: 'user' | 'project') {
@@ -49,6 +60,9 @@ export class ConnectionStore {
       for (const folder of data.folders || []) {
         folder.scope = scope;
         this.folders.set(folder.id, folder);
+      }
+      if (data.settings) {
+        Object.assign(this.settings, data.settings);
       }
     } catch {
       // File doesn't exist or invalid JSON — skip silently
@@ -133,7 +147,11 @@ export class ConnectionStore {
 
   async add(config: ConnectionConfig): Promise<void> {
     this.connections.set(config.id, config);
-    await this.saveUserConfig();
+    if (config.scope === 'project') {
+      await this.saveProjectConfig();
+    } else {
+      await this.saveUserConfig();
+    }
   }
 
   private async saveUserConfig() {
@@ -146,6 +164,36 @@ export class ConnectionStore {
 
     const data: ConfigData = { connections: userConfigs };
     fs.writeFileSync(USER_CONFIG_FILE, JSON.stringify(data, null, 2), 'utf8');
+  }
+
+  private async saveProjectConfig() {
+    const projectFile = path.join(process.cwd(), PROJECT_CONFIG_FILE);
+    const projectConfigs = Array.from(this.connections.values())
+      .filter(c => c.scope === 'project')
+      .map(c => {
+        const { password, ...rest } = c;
+        return rest;
+      });
+
+    const dir = path.dirname(projectFile);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    let existing: ConfigData = { connections: [] };
+    try {
+      if (fs.existsSync(projectFile)) {
+        existing = JSON.parse(fs.readFileSync(projectFile, 'utf8'));
+      }
+    } catch {
+      // invalid JSON — overwrite
+    }
+
+    const existingNonProject = (existing.connections || []).filter(
+      c => !projectConfigs.some(pc => pc.id === c.id),
+    );
+    existing.connections = [...existingNonProject, ...projectConfigs];
+    fs.writeFileSync(projectFile, JSON.stringify(existing, null, 2), 'utf8');
   }
 
   async disconnectAll() {

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -6,7 +6,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { ConnectionStore } from './connectionStore';
+import { ConnectionStore, StandaloneMcpSettings } from './connectionStore';
 import { ChartConfig, EChartsChartType, isGrafanaCompatible, buildAggregationQuery } from '../types/chart';
 import { buildEChartsOption, suggestChartConfig } from '../chart/chartDataTransform';
 import { buildGrafanaDashboard } from '../chart/grafanaExport';
@@ -24,8 +24,38 @@ const server = new Server(
 
 // --- Tool definitions ---
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
+interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: { type: 'object'; properties: Record<string, unknown>; required?: string[] };
+}
+
+const ADD_CONNECTION_TOOL: ToolDef = {
+  name: 'add_connection',
+  description: 'Add a new database connection. For SQLite: set type="sqlite", database="/path/to/file.db" (or ":memory:"), host and port are ignored.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      name: { type: 'string', description: 'Display name' },
+      type: { type: 'string', enum: ['postgresql', 'redis', 'clickhouse', 'sqlite'], description: 'Database type' },
+      host: { type: 'string', description: 'Host (ignored for SQLite)' },
+      port: { type: 'number', description: 'Port (ignored for SQLite)' },
+      username: { type: 'string', description: 'Username' },
+      password: { type: 'string', description: 'Password' },
+      database: { type: 'string', description: 'Database name, or file path for SQLite (e.g. "/tmp/test.db", ":memory:")' },
+      ssl: { type: 'boolean', description: 'Use SSL' },
+      readonly: { type: 'boolean', description: 'Read-only mode' },
+    },
+    required: ['name', 'type'],
+  },
+};
+
+function getAllowAddConnection(): StandaloneMcpSettings['allowAddConnection'] {
+  return store.getSettings().allowAddConnection ?? 'restricted';
+}
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  const tools: ToolDef[] = [
     {
       name: 'list_connections',
       description: 'List all configured database connections with their status. The "databases" field shows additional databases on the same server that can be queried via the "database" parameter of other tools.',
@@ -86,25 +116,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
-      name: 'add_connection',
-      description: 'Add a new database connection. For SQLite: set type="sqlite", database="/path/to/file.db" (or ":memory:"), host and port are ignored.',
-      inputSchema: {
-        type: 'object' as const,
-        properties: {
-          name: { type: 'string', description: 'Display name' },
-          type: { type: 'string', enum: ['postgresql', 'redis', 'clickhouse', 'sqlite'], description: 'Database type' },
-          host: { type: 'string', description: 'Host (ignored for SQLite)' },
-          port: { type: 'number', description: 'Port (ignored for SQLite)' },
-          username: { type: 'string', description: 'Username' },
-          password: { type: 'string', description: 'Password' },
-          database: { type: 'string', description: 'Database name, or file path for SQLite (e.g. "/tmp/test.db", ":memory:")' },
-          ssl: { type: 'boolean', description: 'Use SSL' },
-          readonly: { type: 'boolean', description: 'Read-only mode' },
-        },
-        required: ['name', 'type'],
-      },
-    },
-    {
       name: 'reload_connections',
       description: 'Reload connections from config files (call after adding connections via VS Code or editing config files)',
       inputSchema: { type: 'object' as const, properties: {} },
@@ -150,8 +161,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['connectionId', 'query', 'chartType'],
       },
     },
-  ],
-}));
+  ];
+
+  if (getAllowAddConnection() !== 'off') {
+    tools.push(ADD_CONNECTION_TOOL);
+  }
+
+  return { tools };
+});
 
 // --- Tool handlers ---
 
@@ -223,16 +240,51 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'add_connection': {
+        const mode = getAllowAddConnection();
+        if (mode === 'off') {
+          return errorResponse('Tool disabled. Configure allowAddConnection in ~/.viewstor/connections.json settings.');
+        }
+
         const { name: connName, type, host, port, username, password, database, ssl, readonly } = args as {
-          name: string; type: 'postgresql' | 'redis' | 'clickhouse';
+          name: string; type: 'postgresql' | 'redis' | 'clickhouse' | 'sqlite';
           host: string; port: number;
           username?: string; password?: string; database?: string;
           ssl?: boolean; readonly?: boolean;
         };
         const id = Date.now().toString(36) + Math.random().toString(36).substring(2, 8);
-        const config = { id, name: connName, type, host, port, username, password, database, ssl, readonly };
+        const warnings: { kind: string; message: string }[] = [];
+
+        if (mode === 'restricted') {
+          if (readonly === false) {
+            warnings.push({ kind: 'readonly_forced', message: 'readonly: false was ignored; agent-created connections are always read-only in restricted mode.' });
+          }
+          const restrictedName = connName.startsWith('[agent] ') ? connName : `[agent] ${connName}`;
+          const config = {
+            id, name: restrictedName, type, host, port, username, password, database, ssl,
+            readonly: true,
+            scope: 'project' as const,
+            agentCreated: true,
+          };
+          await store.add(config);
+          return jsonResponse({
+            id, name: restrictedName, type, host, port, database,
+            message: 'Connection added (restricted mode: read-only, project-scoped)',
+            ...(warnings.length > 0 ? { warnings } : {}),
+          });
+        }
+
+        // unrestricted mode
+        const config = {
+          id, name: connName, type, host, port, username, password, database, ssl, readonly,
+          agentCreated: true,
+        };
         await store.add(config);
-        return jsonResponse({ id, name: connName, type, host, port, database, message: 'Connection added' });
+        warnings.push({ kind: 'agent_created_writeable_connection', message: 'Connection created with unrestricted agent access.' });
+        return jsonResponse({
+          id, name: connName, type, host, port, database,
+          message: 'Connection added',
+          warnings,
+        });
       }
 
       case 'reload_connections': {

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -242,7 +242,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'add_connection': {
         const mode = getAllowAddConnection();
         if (mode === 'off') {
-          return errorResponse('Tool disabled. Configure allowAddConnection in ~/.viewstor/connections.json settings.');
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Tool disabled. Configure allowAddConnection in ~/.viewstor/connections.json settings.', kind: 'tool_disabled' }) }],
+            isError: true,
+          };
         }
 
         const { name: connName, type, host, port, username, password, database, ssl, readonly } = args as {

--- a/src/test/addConnectionModes.test.ts
+++ b/src/test/addConnectionModes.test.ts
@@ -68,9 +68,9 @@ describe('add_connection modes', () => {
     expect(store.getSettings().allowAddConnection).toBe('unrestricted');
   });
 
-  // --- Restricted mode (default) ---
+  // --- Store: project-scoped persistence ---
 
-  it('restricted mode: forces readonly=true when agent passes readonly=false', async () => {
+  it('project-scoped save persists readonly flag', async () => {
     writeUserConfig({ connections: [] });
     const store = await loadStore();
     await store.add({
@@ -81,7 +81,7 @@ describe('add_connection modes', () => {
     expect(saved?.readonly).toBe(true);
   });
 
-  it('restricted mode: forces scope=project', async () => {
+  it('project-scoped save persists scope', async () => {
     writeUserConfig({ connections: [] });
     const store = await loadStore();
     await store.add({
@@ -92,7 +92,7 @@ describe('add_connection modes', () => {
     expect(saved?.scope).toBe('project');
   });
 
-  it('restricted mode: project-scoped save strips password', async () => {
+  it('project-scoped save strips password', async () => {
     writeUserConfig({ connections: [] });
     const store = await loadStore();
     await store.add({
@@ -107,7 +107,7 @@ describe('add_connection modes', () => {
     expect(conn.password).toBeUndefined();
   });
 
-  it('restricted mode: prefixes name with [agent]', async () => {
+  it('project-scoped save preserves name', async () => {
     writeUserConfig({ connections: [] });
     const store = await loadStore();
     await store.add({
@@ -116,6 +116,22 @@ describe('add_connection modes', () => {
     });
     const saved = store.get('test-prefix');
     expect(saved?.name).toBe('[agent] My DB');
+  });
+
+  it('user-scoped save preserves settings and folders', async () => {
+    writeUserConfig({
+      connections: [],
+      settings: { allowAddConnection: 'unrestricted' },
+      folders: [{ id: 'f1', name: 'Folder' }],
+    });
+    const store = await loadStore();
+    await store.add({
+      id: 'test-preserve', name: 'Preserve', type: 'postgresql', host: 'localhost', port: 5432,
+      agentCreated: true,
+    });
+    const userData = JSON.parse(fs.readFileSync(USER_CONFIG_FILE, 'utf8'));
+    expect(userData.settings).toEqual({ allowAddConnection: 'unrestricted' });
+    expect(userData.folders).toEqual([{ id: 'f1', name: 'Folder' }]);
   });
 
   // --- Unrestricted mode ---

--- a/src/test/addConnectionModes.test.ts
+++ b/src/test/addConnectionModes.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const TEST_DIR = path.join(os.tmpdir(), `viewstor-add-conn-test-${Date.now()}`);
+const USER_CONFIG_DIR = path.join(TEST_DIR, '.viewstor');
+const USER_CONFIG_FILE = path.join(USER_CONFIG_DIR, 'connections.json');
+const PROJECT_DIR = path.join(TEST_DIR, 'project');
+const PROJECT_CONFIG_FILE = path.join(PROJECT_DIR, '.vscode', 'viewstor.json');
+
+vi.mock('../drivers', () => ({
+  createDriver: vi.fn(() => ({
+    connect: vi.fn(async () => {}),
+    ping: vi.fn(async () => true),
+    disconnect: vi.fn(async () => {}),
+    execute: vi.fn(async () => ({ columns: [], rows: [] })),
+    getSchema: vi.fn(async () => []),
+    getTableData: vi.fn(async () => ({ columns: [], rows: [] })),
+    getTableInfo: vi.fn(async () => ({ columns: [] })),
+  })),
+}));
+
+describe('add_connection modes', () => {
+  const origHome = process.env.HOME;
+  const origCwd = process.cwd();
+
+  beforeEach(() => {
+    fs.mkdirSync(USER_CONFIG_DIR, { recursive: true });
+    fs.mkdirSync(PROJECT_DIR, { recursive: true });
+    process.env.HOME = TEST_DIR;
+    process.chdir(PROJECT_DIR);
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    process.chdir(origCwd);
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  function writeUserConfig(data: Record<string, unknown>) {
+    fs.writeFileSync(USER_CONFIG_FILE, JSON.stringify(data, null, 2), 'utf8');
+  }
+
+  async function loadStore() {
+    const mod = await import('../mcp-server/connectionStore');
+    return new mod.ConnectionStore();
+  }
+
+  // --- Settings loading ---
+
+  it('defaults allowAddConnection to undefined (caller defaults to restricted)', async () => {
+    writeUserConfig({ connections: [] });
+    const store = await loadStore();
+    expect(store.getSettings().allowAddConnection).toBeUndefined();
+  });
+
+  it('reads allowAddConnection from config settings', async () => {
+    writeUserConfig({ connections: [], settings: { allowAddConnection: 'off' } });
+    const store = await loadStore();
+    expect(store.getSettings().allowAddConnection).toBe('off');
+  });
+
+  it('reads allowAddConnection=unrestricted', async () => {
+    writeUserConfig({ connections: [], settings: { allowAddConnection: 'unrestricted' } });
+    const store = await loadStore();
+    expect(store.getSettings().allowAddConnection).toBe('unrestricted');
+  });
+
+  // --- Restricted mode (default) ---
+
+  it('restricted mode: forces readonly=true when agent passes readonly=false', async () => {
+    writeUserConfig({ connections: [] });
+    const store = await loadStore();
+    await store.add({
+      id: 'test-1', name: 'Test', type: 'postgresql', host: 'localhost', port: 5432,
+      readonly: true, scope: 'project', agentCreated: true,
+    });
+    const saved = store.get('test-1');
+    expect(saved?.readonly).toBe(true);
+  });
+
+  it('restricted mode: forces scope=project', async () => {
+    writeUserConfig({ connections: [] });
+    const store = await loadStore();
+    await store.add({
+      id: 'test-2', name: '[agent] PG', type: 'postgresql', host: 'localhost', port: 5432,
+      scope: 'project', agentCreated: true, readonly: true,
+    });
+    const saved = store.get('test-2');
+    expect(saved?.scope).toBe('project');
+  });
+
+  it('restricted mode: project-scoped save strips password', async () => {
+    writeUserConfig({ connections: [] });
+    const store = await loadStore();
+    await store.add({
+      id: 'test-pw', name: '[agent] PW', type: 'postgresql', host: 'localhost', port: 5432,
+      username: 'user', password: 'secret',
+      scope: 'project', agentCreated: true, readonly: true,
+    });
+
+    const projectData = JSON.parse(fs.readFileSync(PROJECT_CONFIG_FILE, 'utf8'));
+    const conn = projectData.connections.find((c: { id: string }) => c.id === 'test-pw');
+    expect(conn).toBeDefined();
+    expect(conn.password).toBeUndefined();
+  });
+
+  it('restricted mode: prefixes name with [agent]', async () => {
+    writeUserConfig({ connections: [] });
+    const store = await loadStore();
+    await store.add({
+      id: 'test-prefix', name: '[agent] My DB', type: 'postgresql', host: 'localhost', port: 5432,
+      scope: 'project', agentCreated: true, readonly: true,
+    });
+    const saved = store.get('test-prefix');
+    expect(saved?.name).toBe('[agent] My DB');
+  });
+
+  // --- Unrestricted mode ---
+
+  it('unrestricted mode: allows readonly=false', async () => {
+    writeUserConfig({ connections: [], settings: { allowAddConnection: 'unrestricted' } });
+    const store = await loadStore();
+    await store.add({
+      id: 'test-unr', name: 'Unr', type: 'postgresql', host: 'localhost', port: 5432,
+      readonly: false, agentCreated: true,
+    });
+    const saved = store.get('test-unr');
+    expect(saved?.readonly).toBe(false);
+  });
+
+  it('unrestricted mode: saves to user config by default', async () => {
+    writeUserConfig({ connections: [], settings: { allowAddConnection: 'unrestricted' } });
+    const store = await loadStore();
+    await store.add({
+      id: 'test-user', name: 'User', type: 'postgresql', host: 'localhost', port: 5432,
+      agentCreated: true,
+    });
+    const userData = JSON.parse(fs.readFileSync(USER_CONFIG_FILE, 'utf8'));
+    const conn = userData.connections.find((c: { id: string }) => c.id === 'test-user');
+    expect(conn).toBeDefined();
+  });
+
+  // --- agentCreated flag ---
+
+  it('sets agentCreated=true on added connections', async () => {
+    writeUserConfig({ connections: [] });
+    const store = await loadStore();
+    await store.add({
+      id: 'test-ac', name: '[agent] AC', type: 'sqlite', host: '', port: 0,
+      database: ':memory:', agentCreated: true, readonly: true, scope: 'project',
+    });
+    expect(store.get('test-ac')?.agentCreated).toBe(true);
+  });
+
+  // --- Off mode ---
+
+  it('off mode: tool is not listed (verified by settings value)', async () => {
+    writeUserConfig({ connections: [], settings: { allowAddConnection: 'off' } });
+    const store = await loadStore();
+    expect(store.getSettings().allowAddConnection).toBe('off');
+  });
+
+  // --- Settings reload ---
+
+  it('reload picks up changed settings', async () => {
+    writeUserConfig({ connections: [], settings: { allowAddConnection: 'restricted' } });
+    const store = await loadStore();
+    expect(store.getSettings().allowAddConnection).toBe('restricted');
+
+    writeUserConfig({ connections: [], settings: { allowAddConnection: 'off' } });
+    store.reload();
+    expect(store.getSettings().allowAddConnection).toBe('off');
+  });
+});

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -34,6 +34,8 @@ export interface ConnectionConfig {
   agentAnonymization?: 'off' | 'heuristic' | 'strict';
   /** How masked cells are transformed. Inherited from folder when unset. */
   agentAnonymizationStrategy?: 'hash' | 'shape' | 'null' | 'redacted';
+  /** Connection was created by an agent via the MCP `add_connection` tool. */
+  agentCreated?: boolean;
 }
 
 export type ProxyType = 'none' | 'ssh' | 'socks5' | 'http';

--- a/src/views/connectionTree.ts
+++ b/src/views/connectionTree.ts
@@ -244,9 +244,10 @@ export class ConnectionTreeProvider implements vscode.TreeDataProvider<Connectio
     item.contextValue = connected ? 'connection-connected' : 'connection-disconnected';
     const iconColor = colorToThemeColor(this.connectionManager.getConnectionColor(config.id));
     item.iconPath = new vscode.ThemeIcon(`viewstor-${config.type}`, iconColor);
-    item.description = connected
+    const hostDesc = connected
       ? (config.type === 'sqlite' ? (config.database || ':memory:') : `${config.host}:${config.port}`)
       : '';
+    item.description = config.agentCreated ? (hostDesc ? `${hostDesc} · agent` : 'agent') : hostDesc;
     item.command = { command: 'viewstor._noop', title: '' };
     return item;
   }


### PR DESCRIPTION
## Summary
- Add `allowAddConnection` setting (`'off' | 'restricted' | 'unrestricted'`, default `'restricted'`) to the standalone MCP server, read from `settings` in `~/.viewstor/connections.json`.
- In `restricted` mode, agent-created connections are forced `readonly: true`, `scope: 'project'` (passwords stripped on save), and name-prefixed `[agent] `; agent-supplied `readonly: false` is ignored with a warning.
- In `off` mode, `add_connection` is removed from tool listing and returns a structured error.
- Tree view shows `agent` badge on connections with `agentCreated: true`.

Closes #119

## Assumptions
- The setting lives in the existing `~/.viewstor/connections.json` under a `settings` key (not a separate file), since the standalone MCP already reads this file and has no other settings mechanism. The VS Code `viewstor.standaloneMcp.allowAddConnection` setting is registered in `package.json` for discoverability.
- Project-scoped saving (`saveProjectConfig`) strips passwords following the same pattern as VS Code's project-scope handling.
- The `agentCreated` flag is a simple boolean on `ConnectionConfig` rather than a richer audit record; the flag is sufficient for tree-view badging and future filtering.

## Manual test cases
- **Golden path (restricted):** Start standalone MCP with default settings → call `add_connection` with `readonly: false` → verify response shows `readonly_forced` warning, name is `[agent] …`, connection is project-scoped → verify `.vscode/viewstor.json` contains the connection without password → verify `execute_query` with UPDATE returns readonly error.
- **Off mode:** Set `"settings": {"allowAddConnection": "off"}` in `~/.viewstor/connections.json` → call `list_tools` → verify `add_connection` is absent → call `add_connection` → verify error response with `tool_disabled` message.
- **Unrestricted mode:** Set `allowAddConnection: "unrestricted"` → call `add_connection` with `readonly: false` → verify connection is saved to user config with `readonly: false` and response includes `agent_created_writeable_connection` warning.
- **Tree badge:** Open VS Code after agent creates a connection → verify `agent` appears in the connection description next to host:port.
- **Reload:** Change setting from `restricted` to `off` → call `reload_connections` → verify `add_connection` disappears from tool listing.

## Checklist
- [x] README — updated MCP section with safety modes documentation
- [x] CHANGELOG — added entry under [Unreleased]
- [x] CLAUDE.md — documented `StandaloneMcpSettings`, `allowAddConnection`, `agentCreated`, `saveProjectConfig`
- [x] l10n — added 4 strings for setting description and enum descriptions
- [ ] Wiki — needs MCP Server page update (not pushed from PR)


---
_Generated by [Claude Code](https://claude.ai/code/session_013PgY4ms5gr9CojWLtoqZB5)_