### PR TITLE
fix(ci): stop mangling PR JSON when detecting the release bump type

### DIFF
--- a/.github/scripts/prepare-release.sh
+++ b/.github/scripts/prepare-release.sh
@@ -17,7 +17,9 @@ LAST_TAG_DATE=$(git log -1 --format=%aI "$LAST_TAG" 2>/dev/null || echo "1970-01
 # 3. Find merged PRs since last tag
 echo "Scanning merged PRs since $LAST_TAG..."
 PRS=$(gh pr list --state merged --base trunk --search "merged:>=${LAST_TAG_DATE}" --json number,labels,body --limit 100)
-PR_COUNT=$(echo "$PRS" | jq length)
+# `printf '%s'`, not `echo`: a PR body reaches us as JSON with escaped newlines, and
+# some shells' echo expands those back into real ones, which is invalid JSON.
+PR_COUNT=$(printf '%s' "$PRS" | jq length)
 echo "Found $PR_COUNT merged PRs"
 
 if [ "$PR_COUNT" -eq 0 ]; then
@@ -28,30 +30,32 @@ fi
 # 4. Determine bump type
 BUMP="patch"
 
-# Check PR labels directly
-for PR_ROW in $(echo "$PRS" | jq -c '.[]'); do
-  PR_LABELS=$(echo "$PR_ROW" | jq -r '.labels[].name' 2>/dev/null || true)
-  if echo "$PR_LABELS" | grep -q "^minor$"; then
+# Check PR labels directly.
+# Read line by line: `for row in $(jq -c '.[]')` word-splits each JSON object on the
+# spaces in its body, handing jq a fragment ("Unfinished string at EOF").
+while IFS= read -r PR_ROW; do
+  PR_LABELS=$(printf '%s' "$PR_ROW" | jq -r '.labels[].name' 2>/dev/null || true)
+  if printf '%s' "$PR_LABELS" | grep -q "^minor$"; then
     BUMP="minor"
     echo "Found 'minor' label on PR — will bump minor version"
     break
   fi
-done
+done < <(printf '%s' "$PRS" | jq -c '.[]')
 
 # Also check linked issue labels
 if [ "$BUMP" = "patch" ]; then
-  for PR_ROW in $(echo "$PRS" | jq -c '.[]'); do
-    PR_BODY=$(echo "$PR_ROW" | jq -r '.body // ""')
-    ISSUE_NUMS=$(echo "$PR_BODY" | grep -oP '(?:Closes|Fixes|Resolves)\s+#\K\d+' || true)
+  while IFS= read -r PR_ROW; do
+    PR_BODY=$(printf '%s' "$PR_ROW" | jq -r '.body // ""')
+    ISSUE_NUMS=$(printf '%s' "$PR_BODY" | grep -oP '(?:Closes|Fixes|Resolves)\s+#\K\d+' || true)
     for INUM in $ISSUE_NUMS; do
       ISSUE_LABELS=$(gh issue view "$INUM" --json labels --jq '.labels[].name' 2>/dev/null || true)
-      if echo "$ISSUE_LABELS" | grep -q "^minor$"; then
+      if printf '%s' "$ISSUE_LABELS" | grep -q "^minor$"; then
         BUMP="minor"
         echo "Found 'minor' label on issue #$INUM — will bump minor version"
         break 2
       fi
     done
-  done
+  done < <(printf '%s' "$PRS" | jq -c '.[]')
 fi
 
 echo "Bump type: $BUMP"


### PR DESCRIPTION
The release workflow for #129 failed at the very first step with `jq: parse error: Unfinished string at EOF`, before the version bump, changelog update, tag, marketplace publish or GitHub Release could run.

`prepare-release.sh` iterates merged PRs with `for PR_ROW in $(echo "$PRS" | jq -c '.[]')`. Unquoted command substitution word-splits on whitespace, so each compact JSON object is torn apart at the spaces inside its `body` and `jq` receives a fragment. Any PR with an ordinary multi-word description trips it.

Two changes:
- read the objects line by line (`while IFS= read -r ... < <(...)`) so each one arrives whole;
- `printf '%s'` instead of `echo` for the JSON, since bodies contain escaped newlines and some shells' builtin `echo` expands them back into real newlines — separately invalid JSON.

## Test plan
- [x] Ran the fixed bump-detection block under `bash -euo pipefail` against the live `gh pr list` output for the two PRs currently in range (#129, #127): both objects parse, labels read correctly, bump resolves to `patch`, next version `0.5.3`
- [x] Confirmed the old form reproduces the exact CI error on the same input