### PR TITLE
release: v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Viewstor are documented here. Format based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.5.3] — 2026-08-18
 
 ### Added
 - **Chained (double-hop) SSH tunnels** — an SSH-proxied connection can now hop through an additional jump host before reaching the database, for bastion + private-subnet topologies where the target isn't reachable directly from the first hop. Configure it under Proxy / Tunnel → "Connect through a second SSH hop (jump host)" in the connection form, including a passphrase field for an encrypted private key on that second hop.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "viewstor",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "viewstor",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "viewstor",
   "displayName": "Viewstor",
   "description": "%extension.description%",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "publisher": "Siyet",
   "license": "AGPL-3.0",
   "icon": "resources/icon.png",


### PR DESCRIPTION
Version bump + changelog date for **v0.5.3**, covering #129 (SSH tunnel fixes, chained double-hop tunnels, SSH endpoint in the tree) and #130 (release-script fix).

Opened by hand because `prepare-release.yml` cannot complete on its own: the script does `git push origin trunk --follow-tags`, and the branch ruleset rejects it —

```
remote: - Changes must be made through a pull request.
remote: - 3 of 3 required status checks are expected.
 ! [remote rejected] trunk -> trunk (push declined due to repository rule violations)
```

Everything before that push succeeded (bump → `0.5.3`, changelog dated, tag created in the runner), so this PR reproduces exactly that commit: the two `package.json`/`package-lock.json` version fields and the `## [Unreleased]` → `## [0.5.3] — 2026-08-18` heading. Nothing else — the lockfile is otherwise untouched.

Once merged, pushing the `v0.5.3` tag triggers `release.yml`, which builds, tests and publishes to the marketplace.

**Follow-up worth filing:** the release workflow is unusable as written against the current ruleset — every run will fail at the same push. It needs to either open a release PR itself, or the ruleset needs a bypass for the release actor.